### PR TITLE
chore: .env.local をgitignoreに追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+.env*.local


### PR DESCRIPTION
## 説明

ローカル開発環境の環境変数ファイル（`.env.local`）をgitignoreに追加します。

これにより、個人の環境変数がうっかりコミットされるのを防ぎます。

## テスト

- ローカル開発環境で `.env.local` を追加してログイン動作確認済み