### PR TITLE
fix: スマホで月切り替えとコピーボタンが横にはみ出る問題を修正

### DIFF
--- a/src/components/layout/month-selector.tsx
+++ b/src/components/layout/month-selector.tsx
@@ -26,19 +26,21 @@ export function MonthSelector({ currentMonth }: MonthSelectorProps) {
   const previousMonth = getPreviousMonth(currentMonth)
 
   return (
-    <div className="flex items-center justify-center gap-4">
-      <Button variant="outline" size="icon" onClick={() => navigateMonth(-1)}>
-        <ChevronLeft className="h-4 w-4" />
-      </Button>
-      <button
-        onClick={goToCurrentMonth}
-        className="text-xl font-bold min-w-[150px] hover:text-blue-600"
-      >
-        {formatMonth(currentMonth)}
-      </button>
-      <Button variant="outline" size="icon" onClick={() => navigateMonth(1)}>
-        <ChevronRight className="h-4 w-4" />
-      </Button>
+    <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center sm:gap-4">
+      <div className="flex items-center gap-2">
+        <Button variant="outline" size="icon" onClick={() => navigateMonth(-1)}>
+          <ChevronLeft className="h-4 w-4" />
+        </Button>
+        <button
+          onClick={goToCurrentMonth}
+          className="text-xl font-bold min-w-[120px] text-center hover:text-blue-600"
+        >
+          {formatMonth(currentMonth)}
+        </button>
+        <Button variant="outline" size="icon" onClick={() => navigateMonth(1)}>
+          <ChevronRight className="h-4 w-4" />
+        </Button>
+      </div>
       <CopyMonthDialog
         currentMonth={currentMonth}
         previousMonth={previousMonth}


### PR DESCRIPTION
- MonthSelectorのレイアウトをスマホでは縦並び、デスクトップでは横並びに変更
- 月切り替えボタンをグループ化してコピーボタンと分離
- 月表示の最小幅を120pxに調整

https://claude.ai/code/session_019ZKmxRZDXz9p2ZMzeNDQmh