### PR TITLE
fix: RLSポリシーを修正してanon keyからのDBアクセスを拒否

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -174,10 +174,12 @@ export default nextConfig
 
 ```
 NEXT_PUBLIC_SUPABASE_URL=your_supabase_url
-NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
+SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key
+APP_PASSWORD_HASH_BASE64=your_password_hash_base64
 ```
 
 | 変数 | 説明 |
 |-----|------|
 | NEXT_PUBLIC_SUPABASE_URL | SupabaseプロジェクトのURL |
-| NEXT_PUBLIC_SUPABASE_ANON_KEY | Supabase匿名キー |
+| SUPABASE_SERVICE_ROLE_KEY | Supabase service role key（サーバー専用、RLSバイパス用） |
+| APP_PASSWORD_HASH_BASE64 | アプリパスワードのbcryptハッシュ（Base64エンコード） |

--- a/docs/database.md
+++ b/docs/database.md
@@ -104,7 +104,7 @@ const month = '202403'
 
 ## Row Level Security (RLS)
 
-Supabaseの RLS を有効化し、データアクセスを制御しています。
+全テーブルでRLSを有効化し、ポリシーを設定していない状態（= 全拒否）にしています。サーバー側ではservice role keyを使用してRLSをバイパスし、Server Actions経由でのみデータアクセスを許可しています。anon keyでの直接アクセスは全て拒否されます。
 
 ## マイグレーション
 
@@ -113,7 +113,8 @@ Supabaseの RLS を有効化し、データアクセスを制御しています�
 ```
 supabase/migrations/
 ├── 001_initial_schema.sql           # 初期スキーマ
-└── 002_change_month_to_varchar.sql  # 月カラムをVARCHAR(6)に変更
+├── 002_change_month_to_varchar.sql  # 月カラムをVARCHAR(6)に変更
+└── 003_restrict_rls_policies.sql    # RLSポリシーを全削除（全拒否化）
 ```
 
 ## トリガー

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slot": "^1.2.4",
-        "@supabase/ssr": "^0.8.0",
         "@supabase/supabase-js": "^2.93.3",
         "bcryptjs": "^3.0.3",
         "class-variance-authority": "^0.7.1",
@@ -3174,18 +3173,6 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@supabase/ssr": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.8.0.tgz",
-      "integrity": "sha512-/PKk8kNFSs8QvvJ2vOww1mF5/c5W8y42duYtXvkOSe+yZKRgTTZywYG2l41pjhNomqESZCpZtXuWmYjFRMV+dw==",
-      "license": "MIT",
-      "dependencies": {
-        "cookie": "^1.0.2"
-      },
-      "peerDependencies": {
-        "@supabase/supabase-js": "^2.76.1"
-      }
-    },
     "node_modules/@supabase/storage-js": {
       "version": "2.93.3",
       "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.93.3.tgz",
@@ -5059,19 +5046,6 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",
-    "@supabase/ssr": "^0.8.0",
     "@supabase/supabase-js": "^2.93.3",
     "bcryptjs": "^3.0.3",
     "class-variance-authority": "^0.7.1",

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,8 +1,0 @@
-import { createBrowserClient } from '@supabase/ssr'
-
-export function createClient() {
-  return createBrowserClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-  )
-}

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,27 +1,8 @@
-import { createServerClient } from '@supabase/ssr'
-import { cookies } from 'next/headers'
+import { createClient as createSupabaseClient } from '@supabase/supabase-js'
 
 export async function createClient() {
-  const cookieStore = await cookies()
-
-  return createServerClient(
+  return createSupabaseClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      cookies: {
-        getAll() {
-          return cookieStore.getAll()
-        },
-        setAll(cookiesToSet) {
-          try {
-            cookiesToSet.forEach(({ name, value, options }) =>
-              cookieStore.set(name, value, options)
-            )
-          } catch {
-            // Server Componentからの呼び出しでは無視
-          }
-        },
-      },
-    }
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
   )
 }

--- a/supabase/migrations/003_restrict_rls_policies.sql
+++ b/supabase/migrations/003_restrict_rls_policies.sql
@@ -1,0 +1,8 @@
+-- RLSポリシーを全削除してanon keyからのアクセスを完全に拒否する
+-- RLS有効 + ポリシーなし = デフォルトで全拒否
+-- service role keyはRLSをバイパスするため、Server Actionsからの操作は引き続き可能
+
+DROP POLICY IF EXISTS "Allow all for authenticated" ON incomes;
+DROP POLICY IF EXISTS "Allow all for authenticated" ON expenses;
+DROP POLICY IF EXISTS "Allow all for authenticated" ON carryovers;
+DROP POLICY IF EXISTS "Allow read for app_settings" ON app_settings;


### PR DESCRIPTION
## 概要

Issue #10のセキュリティ問題を修正しました。Supabase anon keyさえあれば全データにアクセス可能だった状態を改善します。

## 変更内容

- Supabaseクライアントをanon key → **service role key**に切り替え
- RLSポリシーを全削除（RLS有効 + ポリシーなし = デフォルト全拒否）
- anon keyでの直接DB操作を完全に拒否し、Server Actions経由のみ可能に
- 不要な`@supabase/ssr`パッケージを削除

## テスト結果

✅ テスト: 147件全パス
✅ ビルド: 成功
✅ lint: 既存の問題のみ（新規エラーなし）

## マイグレーション

本番環境では以下の手順でマイグレーションを適用してください：
\`\`\`bash
supabase db push
\`\`\`