### PR TITLE
feat: UIをダーク基調 + ネオンアクセントにリデザイン

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "jsdom": "^27.4.0",
         "tailwindcss": "^4",
         "tw-animate-css": "^1.4.0",
-        "typescript": "^5",
+        "typescript": "5.9.3",
         "vitest": "^4.0.18"
       }
     },

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "jsdom": "^27.4.0",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^5",
+    "typescript": "5.9.3",
     "vitest": "^4.0.18"
   }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -44,75 +44,136 @@
   --radius-2xl: calc(var(--radius) + 8px);
   --radius-3xl: calc(var(--radius) + 12px);
   --radius-4xl: calc(var(--radius) + 16px);
+
+  /* ドメインカラー — Tailwindユーティリティ自動生成 */
+  --color-neon-green: var(--neon-green);
+  --color-neon-red: var(--neon-red);
+  --color-neon-cyan: var(--neon-cyan);
+  --color-husband: var(--husband);
+  --color-husband-light: var(--husband-light);
+  --color-wife: var(--wife);
+  --color-wife-light: var(--wife-light);
 }
 
+/* ===== ダーク基調をデフォルトに ===== */
 :root {
-  --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  --radius: 0.75rem;
+
+  /* 背景系 — ダークネイビー */
+  --background: oklch(0.16 0.02 260);
+  --foreground: oklch(0.93 0.01 260);
+  --card: oklch(0.20 0.02 260);
+  --card-foreground: oklch(0.93 0.01 260);
+  --popover: oklch(0.20 0.02 260);
+  --popover-foreground: oklch(0.93 0.01 260);
+
+  /* プライマリ — オフホワイト系 */
+  --primary: oklch(0.93 0.01 260);
+  --primary-foreground: oklch(0.16 0.02 260);
+
+  /* セカンダリ — ダーク面 */
+  --secondary: oklch(0.25 0.02 260);
+  --secondary-foreground: oklch(0.93 0.01 260);
+
+  /* ミュート — 控えめな面 */
+  --muted: oklch(0.25 0.02 260);
+  --muted-foreground: oklch(0.60 0.02 260);
+
+  /* アクセント — ネオンシアン */
+  --accent: oklch(0.75 0.18 195);
+  --accent-foreground: oklch(0.16 0.02 260);
+
+  /* デストラクティブ */
+  --destructive: oklch(0.70 0.20 25);
+
+  /* ボーダー・入力 */
+  --border: oklch(1 0 0 / 8%);
+  --input: oklch(1 0 0 / 12%);
+  --ring: oklch(0.75 0.18 195);
+
+  /* ドメインカラー — ネオンアクセント */
+  --neon-green: oklch(0.75 0.20 155);
+  --neon-red: oklch(0.70 0.20 25);
+  --neon-cyan: oklch(0.80 0.15 195);
+
+  /* 担当者カラー */
+  --husband: oklch(0.70 0.18 250);
+  --husband-light: oklch(0.70 0.18 250 / 15%);
+  --wife: oklch(0.72 0.18 350);
+  --wife-light: oklch(0.72 0.18 350 / 15%);
+
+  /* グロー効果 */
+  --glow-accent: oklch(0.75 0.18 195);
+  --glow-sm: 0 0 8px oklch(0.75 0.18 195 / 15%);
+  --glow-md: 0 0 16px oklch(0.75 0.18 195 / 20%);
+  --glow-lg: 0 0 24px oklch(0.75 0.18 195 / 25%);
+
+  /* チャート */
+  --chart-1: oklch(0.75 0.18 195);
+  --chart-2: oklch(0.75 0.20 155);
+  --chart-3: oklch(0.70 0.18 250);
+  --chart-4: oklch(0.72 0.18 350);
+  --chart-5: oklch(0.70 0.20 25);
+
+  /* サイドバー（未使用だが互換性のため） */
+  --sidebar: oklch(0.18 0.02 260);
+  --sidebar-foreground: oklch(0.93 0.01 260);
+  --sidebar-primary: oklch(0.75 0.18 195);
+  --sidebar-primary-foreground: oklch(0.16 0.02 260);
+  --sidebar-accent: oklch(0.25 0.02 260);
+  --sidebar-accent-foreground: oklch(0.93 0.01 260);
+  --sidebar-border: oklch(1 0 0 / 8%);
+  --sidebar-ring: oklch(0.75 0.18 195);
 }
 
+/* ===== ライトモード ===== */
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  --background: oklch(0.97 0.01 260);
+  --foreground: oklch(0.15 0.02 260);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.15 0.02 260);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.15 0.02 260);
+  --primary: oklch(0.20 0.02 260);
+  --primary-foreground: oklch(0.97 0.01 260);
+  --secondary: oklch(0.94 0.01 260);
+  --secondary-foreground: oklch(0.20 0.02 260);
+  --muted: oklch(0.94 0.01 260);
+  --muted-foreground: oklch(0.45 0.02 260);
+  --accent: oklch(0.55 0.18 195);
+  --accent-foreground: oklch(1 0 0);
+  --destructive: oklch(0.55 0.22 25);
+  --border: oklch(0.90 0.01 260);
+  --input: oklch(0.90 0.01 260);
+  --ring: oklch(0.55 0.18 195);
+
+  --neon-green: oklch(0.50 0.18 155);
+  --neon-red: oklch(0.50 0.20 25);
+  --neon-cyan: oklch(0.55 0.15 195);
+
+  --husband: oklch(0.50 0.18 250);
+  --husband-light: oklch(0.50 0.18 250 / 10%);
+  --wife: oklch(0.55 0.18 350);
+  --wife-light: oklch(0.55 0.18 350 / 10%);
+
+  --glow-sm: 0 1px 3px oklch(0 0 0 / 0.08);
+  --glow-md: 0 2px 8px oklch(0 0 0 / 0.10);
+  --glow-lg: 0 4px 16px oklch(0 0 0 / 0.12);
+
+  --chart-1: oklch(0.55 0.18 195);
+  --chart-2: oklch(0.50 0.18 155);
+  --chart-3: oklch(0.50 0.18 250);
+  --chart-4: oklch(0.55 0.18 350);
+  --chart-5: oklch(0.50 0.20 25);
+
+  --sidebar: oklch(0.97 0.01 260);
+  --sidebar-foreground: oklch(0.15 0.02 260);
+  --sidebar-primary: oklch(0.55 0.18 195);
+  --sidebar-primary-foreground: oklch(1 0 0);
+  --sidebar-accent: oklch(0.94 0.01 260);
+  --sidebar-accent-foreground: oklch(0.20 0.02 260);
+  --sidebar-border: oklch(0.90 0.01 260);
+  --sidebar-ring: oklch(0.55 0.18 195);
 }
 
 @layer base {
@@ -120,6 +181,30 @@
     @apply border-border outline-ring/50;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground antialiased;
   }
+}
+
+/* ===== ユーティリティ ===== */
+@utility font-tabular {
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum";
+}
+
+@utility glow-sm {
+  box-shadow: var(--glow-sm);
+}
+
+@utility glow-md {
+  box-shadow: var(--glow-md);
+}
+
+@utility glow-lg {
+  box-shadow: var(--glow-lg);
+}
+
+@utility glass {
+  background: oklch(from var(--card) l c h / 60%);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -24,13 +24,15 @@ export default async function HomePage({ searchParams }: HomeProps) {
   ])
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-background">
       <Header />
-      <main className="container mx-auto px-4 py-6 space-y-6 max-w-2xl">
+      <main className="container mx-auto px-4 py-8 space-y-6 max-w-4xl">
         <MonthSelector currentMonth={month} />
         <CalculationSection incomes={incomes} expenses={expenses} />
-        <IncomeSection incomes={incomes} month={month} />
-        <ExpenseSection expenses={expenses} month={month} />
+        <div className="grid gap-6 md:grid-cols-2">
+          <IncomeSection incomes={incomes} month={month} />
+          <ExpenseSection expenses={expenses} month={month} />
+        </div>
         <CarryoverSection carryovers={carryovers} month={month} />
       </main>
     </div>

--- a/src/components/forms/edit-dialog.tsx
+++ b/src/components/forms/edit-dialog.tsx
@@ -77,7 +77,7 @@ export function EditDialog({
         <Button
           variant="ghost"
           size="icon"
-          className="h-8 w-8 text-gray-400 hover:text-blue-600"
+          className="h-8 w-8 text-muted-foreground hover:text-accent"
         >
           <Pencil className="h-4 w-4" />
         </Button>
@@ -113,7 +113,7 @@ export function EditDialog({
               </SelectContent>
             </Select>
           </div>
-          {error && <p className="text-sm text-red-600">{error}</p>}
+          {error && <p className="text-sm text-destructive">{error}</p>}
           <div className="flex gap-3 pt-2">
             <Button
               type="button"

--- a/src/components/forms/entry-form.tsx
+++ b/src/components/forms/entry-form.tsx
@@ -59,7 +59,7 @@ export function EntryForm({ type, month, onSubmit }: EntryFormProps) {
           </Select>
         </div>
       </div>
-      <Button type="submit" className="w-full h-12">
+      <Button type="submit" className="w-full h-12 glow-sm hover:glow-md transition-shadow">
         {typeLabels[type]}を追加
       </Button>
     </form>

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -6,11 +6,11 @@ import { logout } from '@/app/actions/auth'
 
 export function Header() {
   return (
-    <header className="bg-white border-b">
-      <div className="container mx-auto px-4 py-3 flex items-center justify-between">
-        <h1 className="text-lg font-bold">家計計算アプリ</h1>
+    <header className="sticky top-0 z-50 glass border-b">
+      <div className="container mx-auto px-4 py-4 flex items-center justify-between">
+        <h1 className="text-xl font-bold tracking-tight">家計計算アプリ</h1>
         <form action={logout}>
-          <Button variant="ghost" size="sm">
+          <Button variant="ghost" size="sm" className="text-muted-foreground hover:text-accent">
             <LogOut className="h-4 w-4 mr-2" />
             ログアウト
           </Button>

--- a/src/components/layout/month-selector.tsx
+++ b/src/components/layout/month-selector.tsx
@@ -34,7 +34,7 @@ export function MonthSelector({ currentMonth }: MonthSelectorProps) {
         </Button>
         <button
           onClick={goToCurrentMonth}
-          className="text-xl font-bold min-w-[120px] text-center hover:text-blue-600"
+          className="text-2xl font-bold min-w-[140px] text-center hover:text-accent transition-colors"
         >
           {formatMonth(currentMonth)}
         </button>

--- a/src/components/sections/calculation-section.tsx
+++ b/src/components/sections/calculation-section.tsx
@@ -14,92 +14,130 @@ export function CalculationSection({
 }: CalculationSectionProps) {
   const result = calculateSettlement(incomes, expenses)
 
+  // バランスバーの比率計算
+  const totalContribution = Math.abs(result.husbandTotal) + Math.abs(result.wifeTotal)
+  const husbandRatio = totalContribution > 0
+    ? (Math.abs(result.husbandTotal) / totalContribution) * 100
+    : 50
+  const wifeRatio = totalContribution > 0
+    ? (Math.abs(result.wifeTotal) / totalContribution) * 100
+    : 50
+
   return (
-    <Card className="bg-blue-50 border-blue-200">
-      <CardHeader className="pb-3">
-        <CardTitle>計算結果</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <div className="grid grid-cols-2 gap-4">
-          {/* 収支合計 */}
-          <div className="space-y-2">
-            <div className="flex justify-between text-sm">
-              <span className="text-gray-600">収入合計</span>
-              <span className="font-medium text-green-600">
+    <div className="space-y-4">
+      {/* 精算額ヒーローカード */}
+      <Card className="relative overflow-hidden border-accent/20 glow-md">
+        <div className="absolute inset-0 bg-gradient-to-br from-accent/5 via-transparent to-neon-cyan/5" />
+        <CardContent className="relative pt-8 pb-8">
+          <div className="text-center space-y-3">
+            <p className="text-xs font-medium text-muted-foreground tracking-widest uppercase">
+              精算額
+            </p>
+            <div className="space-y-2">
+              {result.settlement > 0 ? (
+                <>
+                  <p className="text-5xl md:text-6xl font-bold text-neon-cyan font-mono font-tabular leading-none">
+                    {formatCurrency(result.settlement)}
+                  </p>
+                  <p className="text-base text-muted-foreground font-medium">
+                    夫 → 妻
+                  </p>
+                </>
+              ) : result.settlement < 0 ? (
+                <>
+                  <p className="text-5xl md:text-6xl font-bold text-neon-cyan font-mono font-tabular leading-none">
+                    {formatCurrency(Math.abs(result.settlement))}
+                  </p>
+                  <p className="text-base text-muted-foreground font-medium">
+                    妻 → 夫
+                  </p>
+                </>
+              ) : (
+                <p className="text-3xl md:text-4xl font-bold text-muted-foreground">
+                  精算なし
+                </p>
+              )}
+            </div>
+          </div>
+
+          {/* バランスバー */}
+          <div className="mt-8 space-y-2">
+            <div className="flex items-center justify-between text-sm font-medium">
+              <span className="text-husband">夫</span>
+              <span className="text-wife">妻</span>
+            </div>
+            <div className="relative h-2 bg-muted rounded-full overflow-hidden">
+              <div
+                className="absolute left-0 top-0 h-full bg-husband rounded-l-full transition-all duration-500 ease-out"
+                style={{ width: `${husbandRatio}%` }}
+              />
+              <div
+                className="absolute right-0 top-0 h-full bg-wife rounded-r-full transition-all duration-500 ease-out"
+                style={{ width: `${wifeRatio}%` }}
+              />
+            </div>
+            <div className="flex items-center justify-between text-xs text-muted-foreground font-mono font-tabular">
+              <span>{formatCurrency(result.husbandTotal)}</span>
+              <span>{formatCurrency(result.wifeTotal)}</span>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* 収支詳細カード */}
+      <Card className="glow-sm">
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">収支詳細</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-2 gap-x-6 gap-y-3 text-sm">
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">収入合計</span>
+              <span className="font-medium text-neon-green font-mono font-tabular">
                 {formatCurrency(result.totalIncome)}
               </span>
             </div>
-            <div className="flex justify-between text-sm">
-              <span className="text-gray-600">支出合計</span>
-              <span className="font-medium text-red-600">
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">支出合計</span>
+              <span className="font-medium text-neon-red font-mono font-tabular">
                 {formatCurrency(result.totalExpense)}
               </span>
             </div>
-          </div>
-
-          {/* 担当者別支出 */}
-          <div className="space-y-2">
-            <div className="flex justify-between text-sm">
-              <span className="text-gray-600">夫の支出</span>
-              <span className="font-medium">
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">夫の支出</span>
+              <span className="font-medium font-mono font-tabular">
                 {formatCurrency(result.husbandExpense)}
               </span>
             </div>
-            <div className="flex justify-between text-sm">
-              <span className="text-gray-600">妻の支出</span>
-              <span className="font-medium">
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">妻の支出</span>
+              <span className="font-medium font-mono font-tabular">
                 {formatCurrency(result.wifeExpense)}
               </span>
             </div>
-          </div>
-
-          {/* 担当者別合計 */}
-          <div className="space-y-2">
-            <div className="flex justify-between text-sm">
-              <span className="text-gray-600">夫の合計</span>
-              <span className="font-medium">
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">夫の合計</span>
+              <span className="font-semibold text-husband font-mono font-tabular">
                 {formatCurrency(result.husbandTotal)}
               </span>
             </div>
-            <div className="flex justify-between text-sm">
-              <span className="text-gray-600">妻の合計</span>
-              <span className="font-medium">
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">妻の合計</span>
+              <span className="font-semibold text-wife font-mono font-tabular">
                 {formatCurrency(result.wifeTotal)}
               </span>
             </div>
-          </div>
-
-          {/* お小遣い */}
-          <div className="space-y-2">
-            <div className="flex justify-between text-sm">
-              <span className="text-gray-600">お小遣い（1人あたり）</span>
-              <span className="font-medium text-blue-600">
-                {formatCurrency(result.allowance)}
-              </span>
+            <div className="col-span-2 pt-3 border-t">
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">お小遣い（1人あたり）</span>
+                <span className="font-semibold font-mono font-tabular">
+                  {formatCurrency(result.allowance)}
+                </span>
+              </div>
             </div>
           </div>
-        </div>
-
-        {/* 精算額 */}
-        <div className="mt-6 pt-4 border-t border-blue-200">
-          <div className="text-center">
-            <p className="text-sm text-gray-600 mb-1">精算額</p>
-            <p className="text-2xl font-bold">
-              {result.settlement > 0 ? (
-                <span className="text-orange-600">
-                  夫 → 妻: {formatCurrency(result.settlement)}
-                </span>
-              ) : result.settlement < 0 ? (
-                <span className="text-purple-600">
-                  妻 → 夫: {formatCurrency(Math.abs(result.settlement))}
-                </span>
-              ) : (
-                <span className="text-gray-600">精算なし</span>
-              )}
-            </p>
-          </div>
-        </div>
-      </CardContent>
-    </Card>
+        </CardContent>
+      </Card>
+    </div>
   )
 }

--- a/src/components/sections/carryover-section.tsx
+++ b/src/components/sections/carryover-section.tsx
@@ -26,11 +26,11 @@ export function CarryoverSection({ carryovers, month }: CarryoverSectionProps) {
   const total = carryovers.reduce((sum, c) => sum + c.amount, 0)
 
   return (
-    <Card>
+    <Card className="glow-sm">
       <Collapsible open={isOpen} onOpenChange={setIsOpen}>
         <CardHeader className="pb-3">
           <CollapsibleTrigger asChild>
-            <CardTitle className="flex justify-between items-center cursor-pointer hover:bg-gray-50 -mx-6 -my-4 px-6 py-4">
+            <CardTitle className="flex justify-between items-center cursor-pointer hover:bg-muted/50 -mx-6 -my-4 px-6 py-4 rounded-lg transition-colors">
               <div className="flex items-center gap-2">
                 {isOpen ? (
                   <ChevronDown className="h-4 w-4" />
@@ -38,11 +38,11 @@ export function CarryoverSection({ carryovers, month }: CarryoverSectionProps) {
                   <ChevronRight className="h-4 w-4" />
                 )}
                 <span>繰越（参照用）</span>
-                <span className="text-xs text-gray-500">
+                <span className="text-xs text-muted-foreground">
                   ※精算額には含まれません
                 </span>
               </div>
-              <span className="text-gray-600">{formatCurrency(total)}</span>
+              <span className="text-muted-foreground font-mono font-tabular">{formatCurrency(total)}</span>
             </CardTitle>
           </CollapsibleTrigger>
         </CardHeader>
@@ -59,7 +59,7 @@ export function CarryoverSection({ carryovers, month }: CarryoverSectionProps) {
                     <span>{carryover.label}</span>
                   </div>
                   <div className="flex items-center gap-1">
-                    <span className="font-medium text-gray-600">
+                    <span className="font-medium text-muted-foreground font-mono font-tabular">
                       {formatCurrency(carryover.amount)}
                     </span>
                     <EditDialog
@@ -76,7 +76,7 @@ export function CarryoverSection({ carryovers, month }: CarryoverSectionProps) {
                         type="submit"
                         variant="ghost"
                         size="icon"
-                        className="h-8 w-8 text-gray-400 hover:text-red-600"
+                        className="h-8 w-8 text-muted-foreground hover:text-destructive"
                       >
                         <Trash2 className="h-4 w-4" />
                       </Button>
@@ -85,7 +85,7 @@ export function CarryoverSection({ carryovers, month }: CarryoverSectionProps) {
                 </div>
               ))}
               {carryovers.length === 0 && (
-                <p className="text-sm text-gray-500 text-center py-4">
+                <p className="text-sm text-muted-foreground text-center py-4">
                   繰越がありません
                 </p>
               )}

--- a/src/components/sections/expense-section.tsx
+++ b/src/components/sections/expense-section.tsx
@@ -19,11 +19,11 @@ export function ExpenseSection({ expenses, month }: ExpenseSectionProps) {
   const total = expenses.reduce((sum, e) => sum + e.amount, 0)
 
   return (
-    <Card>
+    <Card className="glow-sm">
       <CardHeader className="pb-3">
         <CardTitle className="flex justify-between items-center">
           <span>支出</span>
-          <span className="text-red-600">{formatCurrency(total)}</span>
+          <span className="text-neon-red font-mono font-tabular">{formatCurrency(total)}</span>
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
@@ -38,7 +38,7 @@ export function ExpenseSection({ expenses, month }: ExpenseSectionProps) {
                 <span>{expense.label}</span>
               </div>
               <div className="flex items-center gap-1">
-                <span className="font-medium text-red-600">
+                <span className="font-medium text-neon-red font-mono font-tabular">
                   {formatCurrency(expense.amount)}
                 </span>
                 <EditDialog
@@ -55,7 +55,7 @@ export function ExpenseSection({ expenses, month }: ExpenseSectionProps) {
                     type="submit"
                     variant="ghost"
                     size="icon"
-                    className="h-8 w-8 text-gray-400 hover:text-red-600"
+                    className="h-8 w-8 text-muted-foreground hover:text-destructive"
                   >
                     <Trash2 className="h-4 w-4" />
                   </Button>
@@ -64,7 +64,7 @@ export function ExpenseSection({ expenses, month }: ExpenseSectionProps) {
             </div>
           ))}
           {expenses.length === 0 && (
-            <p className="text-sm text-gray-500 text-center py-4">
+            <p className="text-sm text-muted-foreground text-center py-4">
               支出がありません
             </p>
           )}

--- a/src/components/sections/income-section.tsx
+++ b/src/components/sections/income-section.tsx
@@ -19,11 +19,11 @@ export function IncomeSection({ incomes, month }: IncomeSectionProps) {
   const total = incomes.reduce((sum, i) => sum + i.amount, 0)
 
   return (
-    <Card>
+    <Card className="glow-sm">
       <CardHeader className="pb-3">
         <CardTitle className="flex justify-between items-center">
           <span>収入</span>
-          <span className="text-green-600">{formatCurrency(total)}</span>
+          <span className="text-neon-green font-mono font-tabular">{formatCurrency(total)}</span>
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
@@ -38,7 +38,7 @@ export function IncomeSection({ incomes, month }: IncomeSectionProps) {
                 <span>{income.label}</span>
               </div>
               <div className="flex items-center gap-1">
-                <span className="font-medium">
+                <span className="font-medium font-mono font-tabular">
                   {formatCurrency(income.amount)}
                 </span>
                 <EditDialog
@@ -55,7 +55,7 @@ export function IncomeSection({ incomes, month }: IncomeSectionProps) {
                     type="submit"
                     variant="ghost"
                     size="icon"
-                    className="h-8 w-8 text-gray-400 hover:text-red-600"
+                    className="h-8 w-8 text-muted-foreground hover:text-destructive"
                   >
                     <Trash2 className="h-4 w-4" />
                   </Button>
@@ -64,7 +64,7 @@ export function IncomeSection({ incomes, month }: IncomeSectionProps) {
             </div>
           ))}
           {incomes.length === 0 && (
-            <p className="text-sm text-gray-500 text-center py-4">
+            <p className="text-sm text-muted-foreground text-center py-4">
               収入がありません
             </p>
           )}

--- a/src/components/ui/person-badge.tsx
+++ b/src/components/ui/person-badge.tsx
@@ -7,11 +7,11 @@ interface PersonBadgeProps {
 const personConfig = {
   husband: {
     label: '夫',
-    className: 'bg-blue-100 text-blue-700',
+    className: 'bg-husband-light text-husband border border-husband/25',
   },
   wife: {
     label: '妻',
-    className: 'bg-pink-100 text-pink-700',
+    className: 'bg-wife-light text-wife border border-wife/25',
   },
 } as const
 
@@ -19,7 +19,7 @@ export function PersonBadge({ person }: PersonBadgeProps) {
   const config = personConfig[person]
 
   return (
-    <span className={`text-xs px-2 py-0.5 rounded font-medium ${config.className}`}>
+    <span className={`text-xs px-2.5 py-1 rounded-md font-semibold ${config.className}`}>
       {config.label}
     </span>
   )


### PR DESCRIPTION
## Summary

Dark Ledger テーマへのUIリデザイン。ダーク基調 + ネオンアクセント、精算額を主役にしたモダンなデザインに変更。新しいカラーシステム（oklch色空間）で統一性のあるライト/ダークモード両対応。バランスバーで夫婦の収支比率を可視化。

## Test plan

- [x] npm run build - ビルド成功
- [x] npm run test:run - 147テスト全パス
- [x] npm run lint - ESLint実行済み
- [ ] ブラウザで目視確認（ダーク/ライトモード、レスポンシブ確認）