### PR TITLE
feat: ボタン操作時のローディングフィードバックを追加

### DIFF
--- a/src/components/forms/edit-dialog.tsx
+++ b/src/components/forms/edit-dialog.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { Pencil } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { SubmitButton } from '@/components/ui/submit-button'
 import {
   Dialog,
   DialogContent,
@@ -50,19 +51,15 @@ export function EditDialog({
 }: EditDialogProps) {
   const [open, setOpen] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [isPending, setIsPending] = useState(false)
 
   // 支出と繰越は負の値で保存されているので、表示時は正の値に変換
   const displayAmount = type === 'income' ? amount : Math.abs(amount)
 
   async function handleSubmit(formData: FormData) {
-    setIsPending(true)
     setError(null)
 
     formData.set('month', month)
     const result = await onUpdate(id, formData)
-
-    setIsPending(false)
 
     if (result.success) {
       setOpen(false)
@@ -123,9 +120,9 @@ export function EditDialog({
             >
               キャンセル
             </Button>
-            <Button type="submit" className="flex-1 h-12" disabled={isPending}>
-              {isPending ? '更新中...' : '更新'}
-            </Button>
+            <SubmitButton className="flex-1 h-12" pendingChildren="更新中...">
+              更新
+            </SubmitButton>
           </div>
         </form>
       </DialogContent>

--- a/src/components/forms/entry-form.tsx
+++ b/src/components/forms/entry-form.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { useRef } from 'react'
-import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { SubmitButton } from '@/components/ui/submit-button'
 import {
   Select,
   SelectContent,
@@ -59,9 +59,12 @@ export function EntryForm({ type, month, onSubmit }: EntryFormProps) {
           </Select>
         </div>
       </div>
-      <Button type="submit" className="w-full h-12 glow-sm hover:glow-md transition-shadow">
+      <SubmitButton
+        className="w-full h-12 glow-sm hover:glow-md transition-shadow"
+        pendingChildren="追加中..."
+      >
         {typeLabels[type]}を追加
-      </Button>
+      </SubmitButton>
     </form>
   )
 }

--- a/src/components/sections/carryover-section.tsx
+++ b/src/components/sections/carryover-section.tsx
@@ -1,15 +1,15 @@
 'use client'
 
 import { useState } from 'react'
-import { ChevronDown, ChevronRight, Trash2 } from 'lucide-react'
+import { ChevronDown, ChevronRight } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Button } from '@/components/ui/button'
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from '@/components/ui/collapsible'
 import { PersonBadge } from '@/components/ui/person-badge'
+import { DeleteButton } from '@/components/ui/delete-button'
 import { EntryForm } from '@/components/forms/entry-form'
 import { EditDialog } from '@/components/forms/edit-dialog'
 import { createCarryover, updateCarryover, deleteCarryover } from '@/app/actions/carryover'
@@ -72,14 +72,7 @@ export function CarryoverSection({ carryovers, month }: CarryoverSectionProps) {
                       onUpdate={updateCarryover}
                     />
                     <form action={async () => { await deleteCarryover(carryover.id) }}>
-                      <Button
-                        type="submit"
-                        variant="ghost"
-                        size="icon"
-                        className="h-8 w-8 text-muted-foreground hover:text-destructive"
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
+                      <DeleteButton />
                     </form>
                   </div>
                 </div>

--- a/src/components/sections/expense-section.tsx
+++ b/src/components/sections/expense-section.tsx
@@ -1,9 +1,8 @@
 'use client'
 
-import { Trash2 } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Button } from '@/components/ui/button'
 import { PersonBadge } from '@/components/ui/person-badge'
+import { DeleteButton } from '@/components/ui/delete-button'
 import { EntryForm } from '@/components/forms/entry-form'
 import { EditDialog } from '@/components/forms/edit-dialog'
 import { createExpense, updateExpense, deleteExpense } from '@/app/actions/expense'
@@ -51,14 +50,7 @@ export function ExpenseSection({ expenses, month }: ExpenseSectionProps) {
                   onUpdate={updateExpense}
                 />
                 <form action={async () => { await deleteExpense(expense.id) }}>
-                  <Button
-                    type="submit"
-                    variant="ghost"
-                    size="icon"
-                    className="h-8 w-8 text-muted-foreground hover:text-destructive"
-                  >
-                    <Trash2 className="h-4 w-4" />
-                  </Button>
+                  <DeleteButton />
                 </form>
               </div>
             </div>

--- a/src/components/sections/income-section.tsx
+++ b/src/components/sections/income-section.tsx
@@ -1,9 +1,8 @@
 'use client'
 
-import { Trash2 } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Button } from '@/components/ui/button'
 import { PersonBadge } from '@/components/ui/person-badge'
+import { DeleteButton } from '@/components/ui/delete-button'
 import { EntryForm } from '@/components/forms/entry-form'
 import { EditDialog } from '@/components/forms/edit-dialog'
 import { createIncome, updateIncome, deleteIncome } from '@/app/actions/income'
@@ -51,14 +50,7 @@ export function IncomeSection({ incomes, month }: IncomeSectionProps) {
                   onUpdate={updateIncome}
                 />
                 <form action={async () => { await deleteIncome(income.id) }}>
-                  <Button
-                    type="submit"
-                    variant="ghost"
-                    size="icon"
-                    className="h-8 w-8 text-muted-foreground hover:text-destructive"
-                  >
-                    <Trash2 className="h-4 w-4" />
-                  </Button>
+                  <DeleteButton />
                 </form>
               </div>
             </div>

--- a/src/components/ui/delete-button.tsx
+++ b/src/components/ui/delete-button.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { useFormStatus } from 'react-dom'
+import { Loader2, Trash2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+export function DeleteButton() {
+  const { pending } = useFormStatus()
+
+  return (
+    <Button
+      type="submit"
+      variant="ghost"
+      size="icon"
+      className="h-8 w-8 text-muted-foreground hover:text-destructive"
+      disabled={pending}
+    >
+      {pending ? (
+        <Loader2 className="h-4 w-4 animate-spin" />
+      ) : (
+        <Trash2 className="h-4 w-4" />
+      )}
+    </Button>
+  )
+}

--- a/src/components/ui/submit-button.tsx
+++ b/src/components/ui/submit-button.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { useFormStatus } from 'react-dom'
+import { Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+interface SubmitButtonProps
+  extends Omit<React.ComponentProps<typeof Button>, 'type' | 'disabled'> {
+  pendingChildren?: React.ReactNode
+}
+
+export function SubmitButton({
+  children,
+  pendingChildren,
+  ...props
+}: SubmitButtonProps) {
+  const { pending } = useFormStatus()
+
+  return (
+    <Button type="submit" disabled={pending} {...props}>
+      {pending ? (
+        pendingChildren ?? (
+          <>
+            <Loader2 className="animate-spin" />
+            {children}
+          </>
+        )
+      ) : (
+        children
+      )}
+    </Button>
+  )
+}


### PR DESCRIPTION
追加・編集・削除ボタンの押下時にローディングスピナー表示とボタン非活性化を行い、
操作が受け付けられたことをユーザーに即座にフィードバックする。
React 19のuseFormStatusを活用したSubmitButtonとDeleteButtonコンポーネントを新規作成。

https://claude.ai/code/session_01TCgbq5YEB2eFZdnVzrhsYB