### PR TITLE
fix: 項目の並び順を金額ベースに変更し、編集時の順序変動を解消

### DIFF
--- a/src/app/actions/carryover.ts
+++ b/src/app/actions/carryover.ts
@@ -18,6 +18,7 @@ export async function getCarryoversByMonth(month: string): Promise<Carryover[]> 
     .select('*')
     .eq('month', month)
     .order('created_at', { ascending: true })
+    .order('id', { ascending: true })
 
   if (error) {
     console.error('繰越取得エラー:', error)

--- a/src/app/actions/copy-month.ts
+++ b/src/app/actions/copy-month.ts
@@ -24,12 +24,14 @@ export async function getCopyMonthPreview(
       .from('incomes')
       .select('id, label, amount, person')
       .eq('month', sourceMonth)
-      .order('created_at', { ascending: true }),
+      .order('amount', { ascending: false })
+      .order('id', { ascending: true }),
     supabase
       .from('expenses')
       .select('id, label, amount, person')
       .eq('month', sourceMonth)
-      .order('created_at', { ascending: true }),
+      .order('amount', { ascending: true })
+      .order('id', { ascending: true }),
     supabase
       .from('carryovers')
       .select('*', { count: 'exact', head: true })

--- a/src/app/actions/expense.ts
+++ b/src/app/actions/expense.ts
@@ -17,7 +17,8 @@ export async function getExpensesByMonth(month: string): Promise<Expense[]> {
     .from('expenses')
     .select('*')
     .eq('month', month)
-    .order('created_at', { ascending: true })
+    .order('amount', { ascending: true })
+    .order('id', { ascending: true })
 
   if (error) {
     console.error('支出取得エラー:', error)

--- a/src/app/actions/income.ts
+++ b/src/app/actions/income.ts
@@ -17,7 +17,8 @@ export async function getIncomesByMonth(month: string): Promise<Income[]> {
     .from('incomes')
     .select('*')
     .eq('month', month)
-    .order('created_at', { ascending: true })
+    .order('amount', { ascending: false })
+    .order('id', { ascending: true })
 
   if (error) {
     console.error('収入取得エラー:', error)

--- a/tests/mocks/supabase.ts
+++ b/tests/mocks/supabase.ts
@@ -72,20 +72,24 @@ vi.mock('@/lib/supabase/server', () => ({
   createClient: vi.fn(async () => mockSupabaseClient),
 }))
 
-// SELECT用: 配列を返す（order()の結果として）
+// SELECT用: 配列を返す（order()が2回チェーンされる前提）
 export function mockSelectSuccess<T>(data: T[]) {
-  mockSupabaseClient._queryBuilder.order.mockResolvedValueOnce({
-    data,
-    error: null,
-  })
+  mockSupabaseClient._queryBuilder.order
+    .mockReturnValueOnce(mockSupabaseClient._queryBuilder)
+    .mockResolvedValueOnce({
+      data,
+      error: null,
+    })
 }
 
 // SELECT用: エラーを返す
 export function mockSelectError(message: string) {
-  mockSupabaseClient._queryBuilder.order.mockResolvedValueOnce({
-    data: null,
-    error: { message },
-  })
+  mockSupabaseClient._queryBuilder.order
+    .mockReturnValueOnce(mockSupabaseClient._queryBuilder)
+    .mockResolvedValueOnce({
+      data: null,
+      error: { message },
+    })
 }
 
 // INSERT/UPDATE用: 単一レコードを返す（single()の結果として）


### PR DESCRIPTION
収入は金額の大きい順（降順）、支出はマイナスが大きい順（昇順）、
繰越は登録順（created_at + idタイブレーカー）でソートするように変更。
従来のcreated_at順ではバルクインサート時にPostgreSQLの行順序が
不安定になり、編集後に並び順が変わる問題があった。

https://claude.ai/code/session_018XavApgiJpyE1sa2yN1Ubf