### PR TITLE
fix: 優先度Highの3件を修正 (#44, #45, #46)

### DIFF
--- a/src/app/actions/carryover.ts
+++ b/src/app/actions/carryover.ts
@@ -3,15 +3,9 @@
 import { revalidatePath } from 'next/cache'
 import { createClient } from '@/lib/supabase/server'
 import { carryoverSchema } from '@/lib/validations/carryover'
-import type { Carryover } from '@/types'
+import type { Carryover, ActionResult } from '@/types'
 
-export interface ActionResult<T = unknown> {
-  success: boolean
-  data?: T
-  error?: string
-}
-
-export async function getCarryoversByMonth(month: string): Promise<Carryover[]> {
+export async function getCarryoversByMonth(month: string): Promise<ActionResult<Carryover[]>> {
   const supabase = await createClient()
   const { data, error } = await supabase
     .from('carryovers')
@@ -22,17 +16,20 @@ export async function getCarryoversByMonth(month: string): Promise<Carryover[]> 
 
   if (error) {
     console.error('繰越取得エラー:', error)
-    return []
+    return { success: false, error: '繰越データの取得に失敗しました' }
   }
 
-  return data.map((row) => ({
-    id: row.id,
-    month: row.month,
-    label: row.label,
-    amount: row.amount,
-    person: row.person,
-    createdAt: row.created_at,
-  }))
+  return {
+    success: true,
+    data: data.map((row) => ({
+      id: row.id,
+      month: row.month,
+      label: row.label,
+      amount: row.amount,
+      person: row.person,
+      createdAt: row.created_at,
+    })),
+  }
 }
 
 export async function createCarryover(

--- a/src/app/actions/copy-month.ts
+++ b/src/app/actions/copy-month.ts
@@ -7,6 +7,7 @@ import type {
   CopyMonthResult,
   CopyMonthPreview,
   CopyItem,
+  ActionResult,
 } from '@/types'
 
 /**
@@ -16,7 +17,7 @@ import type {
 export async function getCopyMonthPreview(
   sourceMonth: string,
   targetMonth: string
-): Promise<CopyMonthPreview> {
+): Promise<ActionResult<CopyMonthPreview>> {
   const supabase = await createClient()
 
   const [incomes, expenses, carryovers, existingCounts] = await Promise.all([
@@ -52,6 +53,15 @@ export async function getCopyMonthPreview(
     ]),
   ])
 
+  if (incomes.error || expenses.error || carryovers.error) {
+    console.error('月コピープレビュー取得エラー:', {
+      incomes: incomes.error,
+      expenses: expenses.error,
+      carryovers: carryovers.error,
+    })
+    return { success: false, error: 'プレビューデータの取得に失敗しました' }
+  }
+
   const items: CopyItem[] = [
     ...(incomes.data ?? []).map((item) => ({
       id: item.id,
@@ -75,11 +85,14 @@ export async function getCopyMonthPreview(
     (existingCounts[2].count ?? 0)
 
   return {
-    sourceMonth,
-    targetMonth,
-    items,
-    carryoverCount: carryovers.count ?? 0,
-    existingCount,
+    success: true,
+    data: {
+      sourceMonth,
+      targetMonth,
+      items,
+      carryoverCount: carryovers.count ?? 0,
+      existingCount,
+    },
   }
 }
 

--- a/src/app/actions/expense.ts
+++ b/src/app/actions/expense.ts
@@ -3,15 +3,9 @@
 import { revalidatePath } from 'next/cache'
 import { createClient } from '@/lib/supabase/server'
 import { expenseSchema } from '@/lib/validations/expense'
-import type { Expense } from '@/types'
+import type { Expense, ActionResult } from '@/types'
 
-export interface ActionResult<T = unknown> {
-  success: boolean
-  data?: T
-  error?: string
-}
-
-export async function getExpensesByMonth(month: string): Promise<Expense[]> {
+export async function getExpensesByMonth(month: string): Promise<ActionResult<Expense[]>> {
   const supabase = await createClient()
   const { data, error } = await supabase
     .from('expenses')
@@ -22,17 +16,20 @@ export async function getExpensesByMonth(month: string): Promise<Expense[]> {
 
   if (error) {
     console.error('支出取得エラー:', error)
-    return []
+    return { success: false, error: '支出データの取得に失敗しました' }
   }
 
-  return data.map((row) => ({
-    id: row.id,
-    month: row.month,
-    label: row.label,
-    amount: row.amount,
-    person: row.person,
-    createdAt: row.created_at,
-  }))
+  return {
+    success: true,
+    data: data.map((row) => ({
+      id: row.id,
+      month: row.month,
+      label: row.label,
+      amount: row.amount,
+      person: row.person,
+      createdAt: row.created_at,
+    })),
+  }
 }
 
 export async function createExpense(

--- a/src/app/actions/income.ts
+++ b/src/app/actions/income.ts
@@ -3,15 +3,9 @@
 import { revalidatePath } from 'next/cache'
 import { createClient } from '@/lib/supabase/server'
 import { incomeSchema } from '@/lib/validations/income'
-import type { Income } from '@/types'
+import type { Income, ActionResult } from '@/types'
 
-export interface ActionResult<T = unknown> {
-  success: boolean
-  data?: T
-  error?: string
-}
-
-export async function getIncomesByMonth(month: string): Promise<Income[]> {
+export async function getIncomesByMonth(month: string): Promise<ActionResult<Income[]>> {
   const supabase = await createClient()
   const { data, error } = await supabase
     .from('incomes')
@@ -22,17 +16,20 @@ export async function getIncomesByMonth(month: string): Promise<Income[]> {
 
   if (error) {
     console.error('収入取得エラー:', error)
-    return []
+    return { success: false, error: '収入データの取得に失敗しました' }
   }
 
-  return data.map((row) => ({
-    id: row.id,
-    month: row.month,
-    label: row.label,
-    amount: row.amount,
-    person: row.person,
-    createdAt: row.created_at,
-  }))
+  return {
+    success: true,
+    data: data.map((row) => ({
+      id: row.id,
+      month: row.month,
+      label: row.label,
+      amount: row.amount,
+      person: row.person,
+      createdAt: row.created_at,
+    })),
+  }
 }
 
 export async function createIncome(

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import { useEffect } from 'react'
+import { AlertCircle, RotateCcw } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+
+interface ErrorProps {
+  error: Error & { digest?: string }
+  reset: () => void
+}
+
+export default function Error({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    console.error('アプリケーションエラー:', error)
+  }, [error])
+
+  return (
+    <div className="min-h-screen gradient-page flex items-center justify-center">
+      <div className="absolute inset-0 overflow-hidden pointer-events-none">
+        <div className="absolute -top-40 -right-40 w-80 h-80 rounded-full bg-destructive/10 blur-3xl" />
+        <div className="absolute -bottom-40 -left-40 w-80 h-80 rounded-full bg-accent/5 blur-3xl" />
+      </div>
+      <Card className="w-full max-w-md relative glow-md animate-fade-in">
+        <CardContent className="pt-8 pb-8">
+          <div className="text-center space-y-4">
+            <div className="mx-auto w-12 h-12 rounded-xl bg-destructive/10 flex items-center justify-center">
+              <AlertCircle className="h-6 w-6 text-destructive" />
+            </div>
+            <div className="space-y-2">
+              <h2 className="text-xl font-bold">エラーが発生しました</h2>
+              <p className="text-sm text-muted-foreground">
+                {error.message || 'データの読み込みに失敗しました。再度お試しください。'}
+              </p>
+            </div>
+            <Button
+              onClick={reset}
+              className="glow-sm hover:glow-md transition-shadow"
+            >
+              <RotateCcw className="h-4 w-4 mr-2" />
+              再試行
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,67 @@
+import { Skeleton } from '@/components/ui/skeleton'
+import { Card, CardContent, CardHeader } from '@/components/ui/card'
+
+export default function Loading() {
+  return (
+    <div className="min-h-screen gradient-page">
+      {/* ヘッダースケルトン */}
+      <header className="sticky top-0 z-50 glass-strong border-b border-border/50">
+        <div className="container mx-auto px-4 py-4 flex items-center justify-between max-w-4xl">
+          <Skeleton className="h-7 w-40" />
+          <div className="flex items-center gap-1">
+            <Skeleton className="h-9 w-9 rounded-md" />
+            <Skeleton className="h-9 w-24 rounded-md" />
+          </div>
+        </div>
+      </header>
+
+      <main className="container mx-auto px-4 py-8 space-y-6 max-w-4xl animate-fade-in">
+        {/* 月セレクター */}
+        <div className="flex items-center justify-center gap-2">
+          <Skeleton className="h-10 w-10 rounded-md" />
+          <Skeleton className="h-8 w-[140px]" />
+          <Skeleton className="h-10 w-10 rounded-md" />
+        </div>
+
+        {/* 精算額カード */}
+        <Card className="relative overflow-hidden border-accent/30 glow-lg">
+          <CardContent className="pt-8 pb-8">
+            <div className="text-center space-y-3">
+              <Skeleton className="h-4 w-12 mx-auto" />
+              <Skeleton className="h-14 w-48 mx-auto" />
+              <Skeleton className="h-5 w-16 mx-auto" />
+            </div>
+            <div className="mt-8">
+              <Skeleton className="h-3 w-full rounded-full" />
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* 収入・支出カード */}
+        <div className="grid gap-6 md:grid-cols-2">
+          {[0, 1].map((i) => (
+            <Card key={i} className="shadow-card">
+              <CardHeader className="pb-3">
+                <div className="flex justify-between items-center">
+                  <Skeleton className="h-6 w-12" />
+                  <Skeleton className="h-6 w-24" />
+                </div>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                {[0, 1, 2].map((j) => (
+                  <div key={j} className="flex items-center justify-between py-2.5">
+                    <div className="flex items-center gap-2">
+                      <Skeleton className="h-6 w-8 rounded-full" />
+                      <Skeleton className="h-5 w-20" />
+                    </div>
+                    <Skeleton className="h-5 w-16" />
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,36 @@
+import Link from 'next/link'
+import { Home } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+
+export default function NotFound() {
+  return (
+    <div className="min-h-screen gradient-page flex items-center justify-center">
+      <div className="absolute inset-0 overflow-hidden pointer-events-none">
+        <div className="absolute -top-40 -right-40 w-80 h-80 rounded-full bg-accent/10 blur-3xl" />
+        <div className="absolute -bottom-40 -left-40 w-80 h-80 rounded-full bg-accent/5 blur-3xl" />
+      </div>
+      <Card className="w-full max-w-md relative glow-md animate-fade-in">
+        <CardContent className="pt-8 pb-8">
+          <div className="text-center space-y-4">
+            <div className="mx-auto w-12 h-12 rounded-xl bg-gradient-to-br from-accent to-accent/70 flex items-center justify-center">
+              <span className="text-accent-foreground text-lg font-bold">?</span>
+            </div>
+            <div className="space-y-2">
+              <h2 className="text-xl font-bold">ページが見つかりません</h2>
+              <p className="text-sm text-muted-foreground">
+                お探しのページは存在しないか、移動した可能性があります。
+              </p>
+            </div>
+            <Button asChild className="glow-sm hover:glow-md transition-shadow">
+              <Link href="/">
+                <Home className="h-4 w-4 mr-2" />
+                ホームに戻る
+              </Link>
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,11 +17,21 @@ export default async function HomePage({ searchParams }: HomeProps) {
   const params = await searchParams
   const month = params.month ?? parseMonth(new Date())
 
-  const [incomes, expenses, carryovers] = await Promise.all([
+  const [incomesResult, expensesResult, carryoversResult] = await Promise.all([
     getIncomesByMonth(month),
     getExpensesByMonth(month),
     getCarryoversByMonth(month),
   ])
+
+  if (!incomesResult.success || !expensesResult.success || !carryoversResult.success) {
+    throw new Error(
+      incomesResult.error ?? expensesResult.error ?? carryoversResult.error ?? 'データの取得に失敗しました'
+    )
+  }
+
+  const incomes = incomesResult.data ?? []
+  const expenses = expensesResult.data ?? []
+  const carryovers = carryoversResult.data ?? []
 
   return (
     <div className="min-h-screen gradient-page">

--- a/src/components/features/copy-month-dialog.tsx
+++ b/src/components/features/copy-month-dialog.tsx
@@ -55,17 +55,29 @@ export function CopyMonthDialog({
   )
   const [includeCarryover, setIncludeCarryover] = useState(true)
 
-  // ダイアログを開いた時にプレビューを取得
-  useEffect(() => {
-    if (open) {
+  // ダイアログ開閉時のハンドラ
+  function handleOpenChange(nextOpen: boolean) {
+    setOpen(nextOpen)
+    if (nextOpen) {
+      // 状態リセット
       setPreview(null)
       setItemSelections(new Map())
       setIncludeCarryover(true)
-      getCopyMonthPreview(previousMonth, currentMonth).then((data) => {
-        setPreview(data)
+    }
+  }
+
+  // ダイアログを開いた時にプレビューを取得
+  useEffect(() => {
+    if (open) {
+      getCopyMonthPreview(previousMonth, currentMonth).then((result) => {
+        if (!result.success || !result.data) {
+          toast.error(result.error ?? 'プレビューの取得に失敗しました')
+          return
+        }
+        setPreview(result.data)
         // デフォルトで全項目を「金額込み」で選択
         const selections = new Map<string, ItemSelection>()
-        data.items.forEach((item) => {
+        result.data.items.forEach((item) => {
           selections.set(item.id, 'withAmount')
         })
         setItemSelections(selections)
@@ -262,7 +274,7 @@ export function CopyMonthDialog({
   }
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
         <Button variant="outline" size="sm" className="gap-1">
           <Copy className="h-4 w-4" />

--- a/src/components/forms/edit-dialog.tsx
+++ b/src/components/forms/edit-dialog.tsx
@@ -1,9 +1,10 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useId } from 'react'
 import { Pencil } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import { SubmitButton } from '@/components/ui/submit-button'
 import {
   Dialog,
@@ -51,6 +52,7 @@ export function EditDialog({
 }: EditDialogProps) {
   const [open, setOpen] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const uniqueId = useId()
 
   // 支出と繰越は負の値で保存されているので、表示時は正の値に変換
   const displayAmount = type === 'income' ? amount : Math.abs(amount)
@@ -74,6 +76,7 @@ export function EditDialog({
         <Button
           variant="ghost"
           size="icon"
+          aria-label={`${label}を編集`}
           className="h-9 w-9 text-muted-foreground hover:text-accent hover:bg-accent/10 transition-colors"
         >
           <Pencil className="h-4 w-4" />
@@ -85,12 +88,13 @@ export function EditDialog({
         </DialogHeader>
         <form action={handleSubmit} className="space-y-4">
           <div className="space-y-2">
-            <label className="text-sm font-medium">項目名</label>
-            <Input name="label" defaultValue={label} required />
+            <Label htmlFor={`${uniqueId}-label`}>項目名</Label>
+            <Input id={`${uniqueId}-label`} name="label" defaultValue={label} required />
           </div>
           <div className="space-y-2">
-            <label className="text-sm font-medium">金額</label>
+            <Label htmlFor={`${uniqueId}-amount`}>金額</Label>
             <Input
+              id={`${uniqueId}-amount`}
               name="amount"
               type="number"
               defaultValue={displayAmount}
@@ -99,9 +103,9 @@ export function EditDialog({
             />
           </div>
           <div className="space-y-2">
-            <label className="text-sm font-medium">担当者</label>
+            <Label htmlFor={`${uniqueId}-person`}>担当者</Label>
             <Select name="person" defaultValue={person}>
-              <SelectTrigger className="w-full">
+              <SelectTrigger id={`${uniqueId}-person`} className="w-full">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>

--- a/src/components/forms/entry-form.tsx
+++ b/src/components/forms/entry-form.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { useRef } from 'react'
+import { useRef, useId } from 'react'
 import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import { SubmitButton } from '@/components/ui/submit-button'
 import {
   Select,
@@ -25,6 +26,7 @@ const typeLabels = {
 
 export function EntryForm({ type, month, onSubmit }: EntryFormProps) {
   const formRef = useRef<HTMLFormElement>(null)
+  const uniqueId = useId()
 
   async function handleSubmit(formData: FormData) {
     formData.set('month', month)
@@ -36,10 +38,15 @@ export function EntryForm({ type, month, onSubmit }: EntryFormProps) {
 
   return (
     <form ref={formRef} action={handleSubmit} className="space-y-3 pt-4 border-t border-border/50">
-      <Input name="label" placeholder="項目名" required />
+      <div>
+        <Label htmlFor={`${uniqueId}-label`} className="sr-only">項目名</Label>
+        <Input id={`${uniqueId}-label`} name="label" placeholder="項目名" required />
+      </div>
       <div className="flex gap-3">
         <div className="flex-1">
+          <Label htmlFor={`${uniqueId}-amount`} className="sr-only">金額</Label>
           <Input
+            id={`${uniqueId}-amount`}
             name="amount"
             type="number"
             placeholder="金額"
@@ -48,8 +55,9 @@ export function EntryForm({ type, month, onSubmit }: EntryFormProps) {
           />
         </div>
         <div className="w-24">
+          <Label htmlFor={`${uniqueId}-person`} className="sr-only">担当者</Label>
           <Select name="person" defaultValue="husband">
-            <SelectTrigger className="w-full">
+            <SelectTrigger id={`${uniqueId}-person`} className="w-full">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>

--- a/src/components/layout/month-selector.tsx
+++ b/src/components/layout/month-selector.tsx
@@ -29,7 +29,7 @@ export function MonthSelector({ currentMonth }: MonthSelectorProps) {
   return (
     <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center sm:gap-4">
       <div className="flex items-center gap-2">
-        <Button variant="outline" size="icon" onClick={() => navigateMonth(-1)}>
+        <Button variant="outline" size="icon" aria-label="前月に移動" onClick={() => navigateMonth(-1)}>
           <ChevronLeft className="h-4 w-4" />
         </Button>
         <button
@@ -38,7 +38,7 @@ export function MonthSelector({ currentMonth }: MonthSelectorProps) {
         >
           {formatMonth(currentMonth)}
         </button>
-        <Button variant="outline" size="icon" onClick={() => navigateMonth(1)}>
+        <Button variant="outline" size="icon" aria-label="翌月に移動" onClick={() => navigateMonth(1)}>
           <ChevronRight className="h-4 w-4" />
         </Button>
       </div>

--- a/src/components/sections/carryover-section.tsx
+++ b/src/components/sections/carryover-section.tsx
@@ -72,7 +72,7 @@ export function CarryoverSection({ carryovers, month }: CarryoverSectionProps) {
                       onUpdate={updateCarryover}
                     />
                     <form action={async () => { await deleteCarryover(carryover.id) }}>
-                      <DeleteButton />
+                      <DeleteButton label={`${carryover.label}を削除`} />
                     </form>
                   </div>
                 </div>

--- a/src/components/sections/expense-section.tsx
+++ b/src/components/sections/expense-section.tsx
@@ -50,7 +50,7 @@ export function ExpenseSection({ expenses, month }: ExpenseSectionProps) {
                   onUpdate={updateExpense}
                 />
                 <form action={async () => { await deleteExpense(expense.id) }}>
-                  <DeleteButton />
+                  <DeleteButton label={`${expense.label}を削除`} />
                 </form>
               </div>
             </div>

--- a/src/components/sections/income-section.tsx
+++ b/src/components/sections/income-section.tsx
@@ -50,7 +50,7 @@ export function IncomeSection({ incomes, month }: IncomeSectionProps) {
                   onUpdate={updateIncome}
                 />
                 <form action={async () => { await deleteIncome(income.id) }}>
-                  <DeleteButton />
+                  <DeleteButton label={`${income.label}を削除`} />
                 </form>
               </div>
             </div>

--- a/src/components/ui/delete-button.tsx
+++ b/src/components/ui/delete-button.tsx
@@ -4,7 +4,11 @@ import { useFormStatus } from 'react-dom'
 import { Loader2, Trash2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 
-export function DeleteButton() {
+interface DeleteButtonProps {
+  label?: string
+}
+
+export function DeleteButton({ label = '削除' }: DeleteButtonProps) {
   const { pending } = useFormStatus()
 
   return (
@@ -12,6 +16,7 @@ export function DeleteButton() {
       type="submit"
       variant="ghost"
       size="icon"
+      aria-label={label}
       className="h-9 w-9 text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors"
       disabled={pending}
     >

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("bg-accent animate-pulse rounded-md", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,10 @@
+// Server Actionsの共通戻り値型
+export interface ActionResult<T = unknown> {
+  success: boolean
+  data?: T
+  error?: string
+}
+
 // 担当者
 export type Person = 'husband' | 'wife'
 

--- a/tests/components/sections/income-section.test.tsx
+++ b/tests/components/sections/income-section.test.tsx
@@ -72,12 +72,17 @@ describe('IncomeSection', () => {
     expect(wifeElements.length).toBeGreaterThanOrEqual(1)
   })
 
-  it('削除ボタンを表示する', () => {
+  it('削除ボタンにaria-labelが設定されている', () => {
     render(<IncomeSection incomes={mockIncomes} month="202601" />)
 
-    // Trash2アイコンを含むボタンが収入の数だけ存在
-    const deleteButtons = screen.getAllByRole('button', { name: '' })
-    // 削除ボタンと編集ボタンが混在するので、総数を確認
-    expect(deleteButtons.length).toBeGreaterThanOrEqual(2)
+    expect(screen.getByRole('button', { name: '給料を削除' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'ボーナスを削除' })).toBeInTheDocument()
+  })
+
+  it('編集ボタンにaria-labelが設定されている', () => {
+    render(<IncomeSection incomes={mockIncomes} month="202601" />)
+
+    expect(screen.getByRole('button', { name: '給料を編集' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'ボーナスを編集' })).toBeInTheDocument()
   })
 })

--- a/tests/integration/actions/carryover.test.ts
+++ b/tests/integration/actions/carryover.test.ts
@@ -51,8 +51,9 @@ describe('carryover actions', () => {
       const result = await getCarryoversByMonth('202601')
 
       expect(mockSupabaseClient.from).toHaveBeenCalledWith('carryovers')
-      expect(result).toHaveLength(2)
-      expect(result[0]).toEqual({
+      expect(result.success).toBe(true)
+      expect(result.data).toHaveLength(2)
+      expect(result.data?.[0]).toEqual({
         id: '1',
         month: '202601',
         label: '前月からの繰越',
@@ -67,15 +68,17 @@ describe('carryover actions', () => {
 
       const result = await getCarryoversByMonth('202601')
 
-      expect(result).toEqual([])
+      expect(result.success).toBe(true)
+      expect(result.data).toEqual([])
     })
 
-    it('エラー時は空配列を返す', async () => {
+    it('エラー時はエラーを返す', async () => {
       mockSelectError('Database error')
 
       const result = await getCarryoversByMonth('202601')
 
-      expect(result).toEqual([])
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('繰越データの取得に失敗しました')
     })
   })
 

--- a/tests/integration/actions/expense.test.ts
+++ b/tests/integration/actions/expense.test.ts
@@ -51,8 +51,9 @@ describe('expense actions', () => {
       const result = await getExpensesByMonth('202601')
 
       expect(mockSupabaseClient.from).toHaveBeenCalledWith('expenses')
-      expect(result).toHaveLength(2)
-      expect(result[0]).toEqual({
+      expect(result.success).toBe(true)
+      expect(result.data).toHaveLength(2)
+      expect(result.data?.[0]).toEqual({
         id: '1',
         month: '202601',
         label: '食費',
@@ -67,15 +68,17 @@ describe('expense actions', () => {
 
       const result = await getExpensesByMonth('202601')
 
-      expect(result).toEqual([])
+      expect(result.success).toBe(true)
+      expect(result.data).toEqual([])
     })
 
-    it('エラー時は空配列を返す', async () => {
+    it('エラー時はエラーを返す', async () => {
       mockSelectError('Database error')
 
       const result = await getExpensesByMonth('202601')
 
-      expect(result).toEqual([])
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('支出データの取得に失敗しました')
     })
   })
 

--- a/tests/integration/actions/income.test.ts
+++ b/tests/integration/actions/income.test.ts
@@ -51,8 +51,9 @@ describe('income actions', () => {
       const result = await getIncomesByMonth('202601')
 
       expect(mockSupabaseClient.from).toHaveBeenCalledWith('incomes')
-      expect(result).toHaveLength(2)
-      expect(result[0]).toEqual({
+      expect(result.success).toBe(true)
+      expect(result.data).toHaveLength(2)
+      expect(result.data?.[0]).toEqual({
         id: '1',
         month: '202601',
         label: '給料',
@@ -67,15 +68,17 @@ describe('income actions', () => {
 
       const result = await getIncomesByMonth('202601')
 
-      expect(result).toEqual([])
+      expect(result.success).toBe(true)
+      expect(result.data).toEqual([])
     })
 
-    it('エラー時は空配列を返す', async () => {
+    it('エラー時はエラーを返す', async () => {
       mockSelectError('Database error')
 
       const result = await getIncomesByMonth('202601')
 
-      expect(result).toEqual([])
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('収入データの取得に失敗しました')
     })
   })
 


### PR DESCRIPTION
## Summary

priority:high の3件のissueに対応

- **#45 Server Actionsのサイレントフェイル修正**: get系関数がエラー時に空配列を返して握りつぶしていた問題を修正。`ActionResult<T[]>` 型を導入し、エラーを適切に伝播するように変更
- **#44 loading/error/not-foundページ追加**: `loading.tsx`（スケルトンUI）、`error.tsx`（エラー境界）、`not-found.tsx`（404）を追加
- **#46 アクセシビリティ改善**: 削除/編集ボタンにaria-label、フォームにLabel要素（sr-only）、月ナビゲーションボタンにaria-labelを追加

### 副次的な修正
- `copy-month-dialog.tsx` の `useEffect` 内 `setState` による lint エラーを修正（状態リセットを `onOpenChange` ハンドラに移動）

## Test plan

- [x] `npm run test:run` — 全153テスト通過
- [x] `npm run build` — ビルドエラーなし
- [x] `npm run lint` — lint エラー0件
- [ ] 手動確認: 存在しないURLにアクセス → not-found.tsx 表示
- [ ] 手動確認: ブラウザのスクリーンリーダーで操作確認（aria-label の読み上げ）

Closes #44, Closes #45, Closes #46