### PR TITLE
feat: Supabase Free プランの自動停止を防ぐ keepalive 機能を追加

### DIFF
--- a/.github/workflows/keep-supabase-awake.yml
+++ b/.github/workflows/keep-supabase-awake.yml
@@ -1,0 +1,21 @@
+name: Keep Supabase Awake
+
+on:
+  schedule:
+    - cron: '0 0 */5 * *'
+  workflow_dispatch:
+
+jobs:
+  keepalive:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Call keepalive endpoint
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          KEEPALIVE_TOKEN: ${{ secrets.SUPABASE_KEEPALIVE_TOKEN }}
+        run: |
+          curl --fail --silent --show-error \
+            --max-time 30 \
+            -H "Authorization: Bearer ${KEEPALIVE_TOKEN}" \
+            "${SUPABASE_URL}/functions/v1/keepalive"

--- a/README.md
+++ b/README.md
@@ -57,6 +57,57 @@ npm run dev
 | `npm run test:coverage` | カバレッジ測定 |
 | `npm run test:e2e` | E2Eテスト |
 
+## Keepalive（Supabase Free プラン対策）
+
+Supabase Free プランではアクティビティが低いプロジェクトが自動で pause されます。これを防ぐため、GitHub Actions で5日に1回 Supabase Edge Function を呼び出します。
+
+### 仕組み
+
+- `supabase/functions/keepalive/index.ts` - 軽量な Edge Function（JSON レスポンスを返すだけ）
+- `.github/workflows/keep-supabase-awake.yml` - 5日に1回自動実行（手動実行も可能）
+
+### セットアップ
+
+#### 1. Supabase Edge Function のデプロイ
+
+```bash
+supabase functions deploy keepalive
+```
+
+#### 2. Supabase 側の Secret 設定
+
+Supabase Dashboard > Edge Functions > Secrets で以下を設定：
+
+| Secret 名 | 値 |
+|-----------|---|
+| `KEEPALIVE_TOKEN` | 任意のランダム文字列（認証用） |
+
+#### 3. GitHub Secrets の設定
+
+リポジトリの Settings > Secrets and variables > Actions で以下を設定：
+
+| Secret 名 | 値 | 説明 |
+|-----------|---|------|
+| `SUPABASE_URL` | `https://<PROJECT_REF>.supabase.co` | Supabase プロジェクト URL |
+| `SUPABASE_KEEPALIVE_TOKEN` | Supabase 側の `KEEPALIVE_TOKEN` と同じ値 | 認証トークン |
+
+### 動作確認
+
+```bash
+# ローカルで関数を起動
+supabase functions serve keepalive
+
+# ローカルで確認
+curl http://localhost:54321/functions/v1/keepalive
+
+# デプロイ後の確認
+curl -H "Authorization: Bearer <KEEPALIVE_TOKEN>" \
+  https://<PROJECT_REF>.supabase.co/functions/v1/keepalive
+
+# GitHub Actions の手動実行
+# リポジトリの Actions タブ > "Keep Supabase Awake" > "Run workflow"
+```
+
 ## ドキュメント
 
 詳細なドキュメントは [docs/](./docs/) ディレクトリを参照してください。

--- a/supabase/functions/keepalive/index.ts
+++ b/supabase/functions/keepalive/index.ts
@@ -1,0 +1,24 @@
+Deno.serve((req: Request) => {
+  if (req.method !== 'GET') {
+    return new Response(JSON.stringify({ ok: false, error: 'Method not allowed' }), {
+      status: 405,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const token = Deno.env.get('KEEPALIVE_TOKEN')
+  if (token) {
+    const auth = req.headers.get('Authorization')
+    if (auth !== `Bearer ${token}`) {
+      return new Response(JSON.stringify({ ok: false, error: 'Unauthorized' }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+  }
+
+  return new Response(JSON.stringify({ ok: true, timestamp: new Date().toISOString() }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "supabase/functions"]
 }


### PR DESCRIPTION
## 概要

Supabase Free プランの inactivity pause を防ぐため、GitHub Actions から定期的に Supabase Edge Function を呼び出す keepalive の仕組みを追加。

## 変更内容

- `supabase/functions/keepalive/index.ts`: 軽量な Edge Function（GET、KEEPALIVE_TOKEN によるトークン認証、JSON レスポンス）
- `.github/workflows/keep-supabase-awake.yml`: 5日に1回自動実行の cron ワークフロー（手動実行対応、secrets は env 経由で安全に渡す）
- `README.md`: Keepalive セクション追加（目的、セットアップ手順、動作確認方法）

## セットアップ

マージ後に以下の設定が必要:

1. `supabase functions deploy keepalive` で Edge Function をデプロイ
2. Supabase Dashboard で `KEEPALIVE_TOKEN` を Secret に設定
3. GitHub Secrets に `SUPABASE_URL` と `SUPABASE_KEEPALIVE_TOKEN` を設定