### PR TITLE
fix: supabase/functions をTypeScriptビルド対象から除外

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "supabase/functions"]
 }


### PR DESCRIPTION
## 概要

PR #58 でマージされた Supabase Edge Function (`supabase/functions/keepalive/`) が Next.js の TypeScript ビルド対象に含まれ、Deno の `Deno.serve` が解決できずビルドエラーになっていた問題を修正。

## 変更内容

- `tsconfig.json` の `exclude` に `supabase/functions` を追加し、Deno 向けコードを Next.js ビルドから除外

## テスト

- [x] `npm run build` 成功を確認