### PR TITLE
feat: 月次CSVエクスポート機能を追加

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -37,7 +37,7 @@ export default async function HomePage({ searchParams }: HomeProps) {
     <div className="min-h-screen gradient-page">
       <Header />
       <main className="container mx-auto px-4 py-8 space-y-6 max-w-4xl">
-        <MonthSelector currentMonth={month} />
+        <MonthSelector currentMonth={month} incomes={incomes} expenses={expenses} carryovers={carryovers} />
         <CalculationSection incomes={incomes} expenses={expenses} />
         <div className="grid gap-6 md:grid-cols-2">
           <IncomeSection incomes={incomes} month={month} />

--- a/src/components/features/export-csv-button.tsx
+++ b/src/components/features/export-csv-button.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { Download } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { generateMonthlyCsv, downloadCsv } from '@/lib/utils/csv'
+import { formatMonth } from '@/lib/utils/format'
+import type { Income, Expense, Carryover } from '@/types'
+
+interface ExportCsvButtonProps {
+  currentMonth: string
+  incomes: Income[]
+  expenses: Expense[]
+  carryovers: Carryover[]
+}
+
+export function ExportCsvButton({
+  currentMonth,
+  incomes,
+  expenses,
+  carryovers,
+}: ExportCsvButtonProps) {
+  function handleExport() {
+    const csv = generateMonthlyCsv(currentMonth, incomes, expenses, carryovers)
+    const filename = `家計データ_${formatMonth(currentMonth)}.csv`
+    downloadCsv(csv, filename)
+  }
+
+  return (
+    <Button variant="outline" size="sm" onClick={handleExport}>
+      <Download className="mr-1.5 h-4 w-4" />
+      CSV出力
+    </Button>
+  )
+}

--- a/src/components/layout/month-selector.tsx
+++ b/src/components/layout/month-selector.tsx
@@ -4,13 +4,18 @@ import { useRouter } from 'next/navigation'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { CopyMonthDialog } from '@/components/features/copy-month-dialog'
+import { ExportCsvButton } from '@/components/features/export-csv-button'
 import { formatMonth, parseMonth, getPreviousMonth } from '@/lib/utils/format'
+import type { Income, Expense, Carryover } from '@/types'
 
 interface MonthSelectorProps {
   currentMonth: string
+  incomes?: Income[]
+  expenses?: Expense[]
+  carryovers?: Carryover[]
 }
 
-export function MonthSelector({ currentMonth }: MonthSelectorProps) {
+export function MonthSelector({ currentMonth, incomes, expenses, carryovers }: MonthSelectorProps) {
   const router = useRouter()
 
   function navigateMonth(offset: number) {
@@ -42,10 +47,20 @@ export function MonthSelector({ currentMonth }: MonthSelectorProps) {
           <ChevronRight className="h-4 w-4" />
         </Button>
       </div>
-      <CopyMonthDialog
-        currentMonth={currentMonth}
-        previousMonth={previousMonth}
-      />
+      <div className="flex gap-2">
+        <CopyMonthDialog
+          currentMonth={currentMonth}
+          previousMonth={previousMonth}
+        />
+        {incomes && expenses && carryovers && (
+          <ExportCsvButton
+            currentMonth={currentMonth}
+            incomes={incomes}
+            expenses={expenses}
+            carryovers={carryovers}
+          />
+        )}
+      </div>
     </div>
   )
 }

--- a/src/lib/utils/csv.ts
+++ b/src/lib/utils/csv.ts
@@ -1,0 +1,81 @@
+import type { Income, Expense, Carryover, Person } from '@/types'
+import { calculateSettlement } from '@/lib/utils/calculation'
+import { formatMonth } from '@/lib/utils/format'
+
+const BOM = '\uFEFF'
+
+function personLabel(person: Person): string {
+  return person === 'husband' ? '夫' : '妻'
+}
+
+function escapeCsvField(value: string): string {
+  if (value.includes(',') || value.includes('"') || value.includes('\n')) {
+    return `"${value.replace(/"/g, '""')}"`
+  }
+  return value
+}
+
+export function generateMonthlyCsv(
+  month: string,
+  incomes: Income[],
+  expenses: Expense[],
+  carryovers: Carryover[]
+): string {
+  const result = calculateSettlement(incomes, expenses)
+  const lines: string[] = []
+
+  // ヘッダー
+  lines.push(`家計データ,${formatMonth(month)}`)
+  lines.push('')
+
+  // サマリーセクション
+  lines.push('■ サマリー')
+  lines.push('項目,金額')
+  lines.push(`収入合計,${result.totalIncome}`)
+  lines.push(`支出合計,${Math.abs(result.totalExpense)}`)
+  lines.push(`夫の収入,${result.husbandIncome}`)
+  lines.push(`妻の収入,${result.wifeIncome}`)
+  lines.push(`夫の支出,${Math.abs(result.husbandExpense)}`)
+  lines.push(`妻の支出,${Math.abs(result.wifeExpense)}`)
+  lines.push(`お小遣い（1人あたり）,${result.allowance}`)
+  lines.push(`精算額,${Math.abs(result.settlement)}`)
+  lines.push(`精算方向,${result.settlement >= 0 ? '夫 → 妻' : '妻 → 夫'}`)
+  lines.push('')
+
+  // 収入セクション
+  lines.push('■ 収入')
+  lines.push('担当,項目名,金額')
+  for (const income of incomes) {
+    lines.push(`${personLabel(income.person)},${escapeCsvField(income.label)},${income.amount}`)
+  }
+  lines.push('')
+
+  // 支出セクション
+  lines.push('■ 支出')
+  lines.push('担当,項目名,金額')
+  for (const expense of expenses) {
+    lines.push(`${personLabel(expense.person)},${escapeCsvField(expense.label)},${Math.abs(expense.amount)}`)
+  }
+  lines.push('')
+
+  // 繰越セクション
+  lines.push('■ 繰越')
+  lines.push('担当,項目名,金額')
+  for (const carryover of carryovers) {
+    lines.push(`${personLabel(carryover.person)},${escapeCsvField(carryover.label)},${Math.abs(carryover.amount)}`)
+  }
+
+  return BOM + lines.join('\n')
+}
+
+export function downloadCsv(csvContent: string, filename: string): void {
+  const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8' })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = filename
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+  URL.revokeObjectURL(url)
+}

--- a/tests/unit/csv.test.ts
+++ b/tests/unit/csv.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest'
+import { generateMonthlyCsv } from '@/lib/utils/csv'
+import type { Income, Expense, Carryover } from '@/types'
+
+describe('generateMonthlyCsv', () => {
+  const incomes: Income[] = [
+    { id: '1', month: '202604', label: '夫手取り', amount: 500000, person: 'husband' },
+    { id: '2', month: '202604', label: '妻手取り', amount: 200000, person: 'wife' },
+  ]
+
+  const expenses: Expense[] = [
+    { id: '1', month: '202604', label: '家賃', amount: -150000, person: 'husband' },
+    { id: '2', month: '202604', label: '食費', amount: -80000, person: 'wife' },
+  ]
+
+  const carryovers: Carryover[] = [
+    { id: '1', month: '202604', label: '前月繰越', amount: -5000, person: 'husband' },
+  ]
+
+  it('BOMプレフィックスが付与される', () => {
+    const csv = generateMonthlyCsv('202604', incomes, expenses, carryovers)
+    expect(csv.charCodeAt(0)).toBe(0xfeff)
+  })
+
+  it('ヘッダーに月が日本語形式で含まれる', () => {
+    const csv = generateMonthlyCsv('202604', incomes, expenses, carryovers)
+    expect(csv).toContain('家計データ,2026年4月')
+  })
+
+  it('サマリーセクションに正しい計算結果が含まれる', () => {
+    const csv = generateMonthlyCsv('202604', incomes, expenses, carryovers)
+    expect(csv).toContain('収入合計,700000')
+    expect(csv).toContain('支出合計,230000')
+    expect(csv).toContain('夫の収入,500000')
+    expect(csv).toContain('妻の収入,200000')
+    expect(csv).toContain('夫の支出,150000')
+    expect(csv).toContain('妻の支出,80000')
+  })
+
+  it('精算方向が正しく表示される', () => {
+    const csv = generateMonthlyCsv('202604', incomes, expenses, carryovers)
+    // settlement = husbandTotal - allowance = (500000 - 150000) - (700000 - 230000) / 2 = 350000 - 235000 = 115000
+    expect(csv).toContain('精算額,115000')
+    expect(csv).toContain('精算方向,夫 → 妻')
+  })
+
+  it('支出・繰越の金額が正の値で出力される', () => {
+    const csv = generateMonthlyCsv('202604', incomes, expenses, carryovers)
+    const lines = csv.split('\n')
+
+    // 支出セクションの家賃行
+    const rentLine = lines.find((l) => l.includes('家賃'))
+    expect(rentLine).toBe('夫,家賃,150000')
+
+    // 繰越セクションの繰越行
+    const carryoverLine = lines.find((l) => l.includes('前月繰越'))
+    expect(carryoverLine).toBe('夫,前月繰越,5000')
+  })
+
+  it('担当者が日本語で表示される', () => {
+    const csv = generateMonthlyCsv('202604', incomes, expenses, carryovers)
+    const lines = csv.split('\n')
+    const incomeLine = lines.find((l) => l.includes('夫手取り'))
+    expect(incomeLine).toBe('夫,夫手取り,500000')
+  })
+
+  it('カンマを含むラベルがCSVエスケープされる', () => {
+    const incomesWithComma: Income[] = [
+      { id: '1', month: '202604', label: '手取り,賞与込み', amount: 500000, person: 'husband' },
+    ]
+    const csv = generateMonthlyCsv('202604', incomesWithComma, [], [])
+    expect(csv).toContain('夫,"手取り,賞与込み",500000')
+  })
+
+  it('ダブルクォートを含むラベルがエスケープされる', () => {
+    const incomesWithQuote: Income[] = [
+      { id: '1', month: '202604', label: '手取り"特別"', amount: 500000, person: 'husband' },
+    ]
+    const csv = generateMonthlyCsv('202604', incomesWithQuote, [], [])
+    expect(csv).toContain('夫,"手取り""特別""",500000')
+  })
+
+  it('空データでも有効なCSVが生成される', () => {
+    const csv = generateMonthlyCsv('202604', [], [], [])
+    expect(csv).toContain('家計データ,2026年4月')
+    expect(csv).toContain('収入合計,0')
+    expect(csv).toContain('支出合計,0')
+    expect(csv).toContain('精算額,0')
+  })
+
+  it('妻→夫の精算方向が正しく表示される', () => {
+    const wifeHigherIncomes: Income[] = [
+      { id: '1', month: '202604', label: '夫手取り', amount: 100000, person: 'husband' },
+      { id: '2', month: '202604', label: '妻手取り', amount: 500000, person: 'wife' },
+    ]
+    const csv = generateMonthlyCsv('202604', wifeHigherIncomes, [], [])
+    expect(csv).toContain('精算方向,妻 → 夫')
+  })
+})


### PR DESCRIPTION
月セレクター横に「CSV出力」ボタンを追加し、選択中の月の収入・支出・繰越・
精算結果をBOM付きUTF-8のCSVファイルとしてダウンロードできるようにした。

https://claude.ai/code/session_017A5LuJpfg7Jb8UNZpLoWzP