### PR TITLE
fix: 前月コピーで繰越フラグ付き支出を選択リストから除外

### DIFF
--- a/src/app/actions/copy-month.ts
+++ b/src/app/actions/copy-month.ts
@@ -62,6 +62,11 @@ export async function getCopyMonthPreview(
     return { success: false, error: 'プレビューデータの取得に失敗しました' }
   }
 
+  // 繰越フラグ付き支出はリストから除外し、繰越の一括コピーに含める
+  const expenseData = expenses.data ?? []
+  const regularExpenses = expenseData.filter((item) => !item.is_carryover)
+  const carryoverExpenseCount = expenseData.filter((item) => item.is_carryover).length
+
   const items: CopyItem[] = [
     ...(incomes.data ?? []).map((item) => ({
       id: item.id,
@@ -70,13 +75,12 @@ export async function getCopyMonthPreview(
       person: item.person,
       type: 'income' as const,
     })),
-    ...(expenses.data ?? []).map((item) => ({
+    ...regularExpenses.map((item) => ({
       id: item.id,
       label: item.label,
       amount: item.amount,
       person: item.person,
       type: 'expense' as const,
-      isCarryover: item.is_carryover ?? false,
     })),
   ]
 
@@ -91,7 +95,7 @@ export async function getCopyMonthPreview(
       sourceMonth,
       targetMonth,
       items,
-      carryoverCount: carryovers.count ?? 0,
+      carryoverCount: (carryovers.count ?? 0) + carryoverExpenseCount,
       existingCount,
     },
   }
@@ -106,12 +110,20 @@ async function copyCarryovers(
   targetMonth: string,
   mode: 'add' | 'skip' | 'replace'
 ): Promise<{ copied: number; skipped: number }> {
-  const { data: sourceData, error } = await supabase
-    .from('carryovers')
-    .select('label, amount, person, is_cleared')
-    .eq('month', sourceMonth)
+  // 繰越テーブルのレコードと、繰越フラグ付き支出の両方を取得
+  const [carryoverResult, carryoverExpenseResult] = await Promise.all([
+    supabase
+      .from('carryovers')
+      .select('label, amount, person, is_cleared')
+      .eq('month', sourceMonth),
+    supabase
+      .from('expenses')
+      .select('label, amount, person')
+      .eq('month', sourceMonth)
+      .eq('is_carryover', true),
+  ])
 
-  if (error || !sourceData) {
+  if (carryoverResult.error || carryoverExpenseResult.error) {
     throw new Error('繰越の取得に失敗しました')
   }
 
@@ -137,13 +149,31 @@ async function copyCarryovers(
     person: string
   }> = []
 
-  for (const item of sourceData) {
-    // 清算済み繰越はコピーしない
+  // 繰越テーブルのレコードを処理（清算済みはスキップ）
+  for (const item of carryoverResult.data ?? []) {
     if (item.is_cleared) {
       skipped++
       continue
     }
 
+    const key = `${item.label}|${item.person}`
+
+    if (mode === 'skip' && existingKeys.has(key)) {
+      skipped++
+      continue
+    }
+
+    itemsToInsert.push({
+      month: targetMonth,
+      label: item.label,
+      amount: item.amount,
+      person: item.person,
+    })
+    copied++
+  }
+
+  // 繰越フラグ付き支出も繰越としてコピー
+  for (const item of carryoverExpenseResult.data ?? []) {
     const key = `${item.label}|${item.person}`
 
     if (mode === 'skip' && existingKeys.has(key)) {
@@ -255,13 +285,6 @@ export async function copyMonthData(
       amount: number
       person: string
     }> = []
-    // 繰越フラグ付き支出は繰越テーブルに変換
-    const carryoverFromExpenseItems: Array<{
-      month: string
-      label: string
-      amount: number
-      person: string
-    }> = []
 
     for (const item of options.selectedItems) {
       const key = `${item.label}|${item.person}`
@@ -291,10 +314,6 @@ export async function copyMonthData(
       if (item.type === 'income') {
         incomeItems.push(newItem)
         result.copied.incomes++
-      } else if (item.isCarryover) {
-        // 繰越フラグ付き支出は繰越テーブルに変換
-        carryoverFromExpenseItems.push(newItem)
-        result.copied.carryovers++
       } else {
         expenseItems.push(newItem)
         result.copied.expenses++
@@ -309,11 +328,6 @@ export async function copyMonthData(
     if (expenseItems.length > 0) {
       const { error } = await supabase.from('expenses').insert(expenseItems)
       if (error) throw new Error(`支出の挿入に失敗: ${error.message}`)
-    }
-
-    if (carryoverFromExpenseItems.length > 0) {
-      const { error } = await supabase.from('carryovers').insert(carryoverFromExpenseItems)
-      if (error) throw new Error(`繰越（支出からの変換）の挿入に失敗: ${error.message}`)
     }
 
     // 繰越を一括コピー

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -67,7 +67,6 @@ export interface CopyItem {
   amount: number
   person: Person
   type: 'income' | 'expense'
-  isCarryover?: boolean // 支出が繰越扱いの場合true
 }
 
 // 選択されたコピー項目（コピーモード付き）

--- a/tests/integration/actions/copy-month.test.ts
+++ b/tests/integration/actions/copy-month.test.ts
@@ -155,46 +155,61 @@ describe('copy-month actions', () => {
         expect(result.copied.expenses).toBe(1)
       })
 
-      it('繰越フラグ付き支出は繰越テーブルにコピーされる', async () => {
+      it('繰越フラグ付き支出はincludeCarryover経由で繰越テーブルにコピーされる', async () => {
         const qb = mockSupabaseClient._queryBuilder
+
+        // copyCarryovers内のPromise.all:
+        // 1. carryovers.select().eq(month) → resolve
+        // 2. expenses.select().eq(month).eq(is_carryover) → chain, resolve
+        qb.select.mockReturnValue(qb)
+        qb.eq.mockResolvedValueOnce({
+          data: [],
+          error: null,
+        })
+        qb.eq.mockReturnValueOnce(qb) // expenses.eq(month) → chain
+        qb.eq.mockResolvedValueOnce({
+          data: [
+            { label: '前月未払い', amount: -30000, person: 'husband' },
+          ],
+          error: null,
+        })
+
         qb.insert.mockResolvedValue({ data: null, error: null })
 
         const options: CopyMonthOptions = {
           sourceMonth: '202601',
           targetMonth: '202602',
           mode: 'add',
-          selectedItems: [
-            {
-              id: '1',
-              label: '前月未払い',
-              amount: -30000,
-              person: 'husband',
-              type: 'expense',
-              isCarryover: true,
-              itemCopyMode: 'withAmount',
-            },
-          ],
-          includeCarryover: false,
+          selectedItems: [],
+          includeCarryover: true,
         }
 
         const result = await copyMonthData(options)
 
         expect(result.success).toBe(true)
-        expect(result.copied.expenses).toBe(0)
         expect(result.copied.carryovers).toBe(1)
         expect(mockSupabaseClient.from).toHaveBeenCalledWith('carryovers')
-        expect(qb.insert).toHaveBeenCalledWith([
-          {
-            month: '202602',
-            label: '前月未払い',
-            amount: -30000,
-            person: 'husband',
-          },
-        ])
       })
 
-      it('繰越フラグ付き支出と通常支出が混在する場合、それぞれ正しいテーブルにコピーされる', async () => {
+      it('繰越フラグ付き支出と繰越テーブルのレコードが両方コピーされる', async () => {
         const qb = mockSupabaseClient._queryBuilder
+
+        // copyCarryovers内のPromise.all:
+        qb.select.mockReturnValue(qb)
+        qb.eq.mockResolvedValueOnce({
+          data: [
+            { label: '前月繰越', amount: -10000, person: 'wife', is_cleared: false },
+          ],
+          error: null,
+        })
+        qb.eq.mockReturnValueOnce(qb) // expenses.eq(month) → chain
+        qb.eq.mockResolvedValueOnce({
+          data: [
+            { label: '前月未払い', amount: -30000, person: 'husband' },
+          ],
+          error: null,
+        })
+
         qb.insert.mockResolvedValue({ data: null, error: null })
 
         const options: CopyMonthOptions = {
@@ -208,27 +223,17 @@ describe('copy-month actions', () => {
               amount: -50000,
               person: 'wife',
               type: 'expense',
-              isCarryover: false,
-              itemCopyMode: 'withAmount',
-            },
-            {
-              id: '2',
-              label: '前月未払い',
-              amount: -30000,
-              person: 'husband',
-              type: 'expense',
-              isCarryover: true,
               itemCopyMode: 'withAmount',
             },
           ],
-          includeCarryover: false,
+          includeCarryover: true,
         }
 
         const result = await copyMonthData(options)
 
         expect(result.success).toBe(true)
         expect(result.copied.expenses).toBe(1)
-        expect(result.copied.carryovers).toBe(1)
+        expect(result.copied.carryovers).toBe(2)
       })
     })
 
@@ -317,12 +322,19 @@ describe('copy-month actions', () => {
       it('includeCarryover=trueで繰越をコピーする', async () => {
         const qb = mockSupabaseClient._queryBuilder
 
-        // 繰越データの取得
+        // copyCarryovers内のPromise.all:
+        // 1. carryovers.select().eq(month) → eq call 1 (resolve)
+        // 2. expenses.select().eq(month).eq(is_carryover) → eq call 2 (chain), eq call 3 (resolve)
         qb.select.mockReturnValue(qb)
         qb.eq.mockResolvedValueOnce({
           data: [
             { label: '前月繰越', amount: -10000, person: 'husband', is_cleared: false },
           ],
+          error: null,
+        })
+        qb.eq.mockReturnValueOnce(qb) // expenses.eq(month) → chain
+        qb.eq.mockResolvedValueOnce({
+          data: [],
           error: null,
         })
 
@@ -346,13 +358,17 @@ describe('copy-month actions', () => {
       it('清算済み繰越はコピーされずスキップされる', async () => {
         const qb = mockSupabaseClient._queryBuilder
 
-        // 繰越データの取得（清算済みと未清算の混在）
         qb.select.mockReturnValue(qb)
         qb.eq.mockResolvedValueOnce({
           data: [
             { label: '前月繰越', amount: -10000, person: 'husband', is_cleared: false },
             { label: '清算済み繰越', amount: -5000, person: 'wife', is_cleared: true },
           ],
+          error: null,
+        })
+        qb.eq.mockReturnValueOnce(qb) // expenses.eq(month) → chain
+        qb.eq.mockResolvedValueOnce({
+          data: [],
           error: null,
         })
 
@@ -383,6 +399,11 @@ describe('copy-month actions', () => {
             { label: '清算済み1', amount: -10000, person: 'husband', is_cleared: true },
             { label: '清算済み2', amount: -5000, person: 'wife', is_cleared: true },
           ],
+          error: null,
+        })
+        qb.eq.mockReturnValueOnce(qb) // expenses.eq(month) → chain
+        qb.eq.mockResolvedValueOnce({
+          data: [],
           error: null,
         })
 
@@ -492,9 +513,24 @@ describe('copy-month actions', () => {
         expect(result.error).toContain('支出の挿入に失敗')
       })
 
-      it('繰越フラグ付き支出の挿入エラー時にエラーを返す', async () => {
+      it('繰越の挿入エラー時にエラーを返す', async () => {
         const qb = mockSupabaseClient._queryBuilder
-        // 繰越（支出からの変換）挿入は失敗
+
+        // copyCarryovers内のPromise.all:
+        qb.select.mockReturnValue(qb)
+        qb.eq.mockResolvedValueOnce({
+          data: [
+            { label: '前月繰越', amount: -10000, person: 'husband', is_cleared: false },
+          ],
+          error: null,
+        })
+        qb.eq.mockReturnValueOnce(qb) // expenses.eq(month) → chain
+        qb.eq.mockResolvedValueOnce({
+          data: [],
+          error: null,
+        })
+
+        // 繰越挿入は失敗
         qb.insert.mockResolvedValueOnce({
           data: null,
           error: { message: 'Insert failed' },
@@ -504,24 +540,14 @@ describe('copy-month actions', () => {
           sourceMonth: '202601',
           targetMonth: '202602',
           mode: 'add',
-          selectedItems: [
-            {
-              id: '1',
-              label: '前月未払い',
-              amount: -30000,
-              person: 'husband',
-              type: 'expense',
-              isCarryover: true,
-              itemCopyMode: 'withAmount',
-            },
-          ],
-          includeCarryover: false,
+          selectedItems: [],
+          includeCarryover: true,
         }
 
         const result = await copyMonthData(options)
 
         expect(result.success).toBe(false)
-        expect(result.error).toContain('繰越（支出からの変換）の挿入に失敗')
+        expect(result.error).toContain('繰越の挿入に失敗')
       })
     })
 


### PR DESCRIPTION
前月からのコピー機能で、繰越フラグ付き支出（`is_carryover=true`）がコピーモーダルの支出リストに表示されていたが、コピー時に自動で繰越テーブルに変換される仕様のためユーザーが選択/解除できるのは不適切だった。繰越フラグ付き支出をプレビューの支出リストから除外し、繰越の一括コピー（`includeCarryover`チェックボックス）の件数に含めるよう変更。`copyCarryovers()`を拡張して繰越フラグ付き支出も一括コピー対象に含め、`copyMonthData()`の個別変換処理を削除した。