### PR TITLE
fix: keepalive Edge FunctionにDBクエリを追加しcron間隔を短縮

### DIFF
--- a/.github/workflows/keep-supabase-awake.yml
+++ b/.github/workflows/keep-supabase-awake.yml
@@ -2,7 +2,7 @@ name: Keep Supabase Awake
 
 on:
   schedule:
-    - cron: '0 0 */5 * *'
+    - cron: '0 0 */3 * *'
   workflow_dispatch:
 
 jobs:

--- a/supabase/functions/keepalive/index.ts
+++ b/supabase/functions/keepalive/index.ts
@@ -1,4 +1,6 @@
-Deno.serve((req: Request) => {
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+Deno.serve(async (req: Request) => {
   if (req.method !== 'GET') {
     return new Response(JSON.stringify({ ok: false, error: 'Method not allowed' }), {
       status: 405,
@@ -17,8 +19,24 @@ Deno.serve((req: Request) => {
     }
   }
 
-  return new Response(JSON.stringify({ ok: true, timestamp: new Date().toISOString() }), {
-    status: 200,
-    headers: { 'Content-Type': 'application/json' },
-  })
+  const supabase = createClient(
+    Deno.env.get('SUPABASE_URL')!,
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
+  )
+
+  const { count, error } = await supabase
+    .from('incomes')
+    .select('*', { count: 'exact', head: true })
+
+  if (error) {
+    return new Response(JSON.stringify({ ok: false, error: error.message }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  return new Response(
+    JSON.stringify({ ok: true, timestamp: new Date().toISOString(), incomes_count: count }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } },
+  )
 })


### PR DESCRIPTION
Edge Functionが静的JSONを返すだけでDBにアクセスしていなかったため、
Supabaseがアクティビティとして検知できずポーズ警告が発生していた。
incomesテーブルへの軽量countクエリを追加し、cron間隔を*/5から*/3に
変更して2月末の8日間ギャップ(7日閾値超過)を解消。

https://claude.ai/code/session_01C3yYLWb6JfZZ7mGQDynymP