### PR TITLE
feat: Soft Cardsデザインに刷新

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,9 @@ next-env.d.ts
 # claude code
 .claude/settings.local.json
 __pycache__/
+
+# playwright mcp
+.playwright-mcp/
+
+# screenshots
+screenshot-*.png

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,7 +6,7 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: "Geist", "Geist Fallback", ui-sans-serif, system-ui, sans-serif;
+  --font-sans: "Inter", "Inter Fallback", ui-sans-serif, system-ui, sans-serif;
   --font-mono: "Geist Mono", "Geist Mono Fallback", ui-monospace, monospace;
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
@@ -65,210 +65,202 @@
 :root {
   --radius: 0.75rem;
 
-  /* 背景系 — Soft Cards: 純白 */
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.20 0.04 260);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.20 0.04 260);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.20 0.04 260);
+  /* 背景系 */
+  --background: #FAFBFC;
+  --foreground: #1A1A1A;
+  --card: #FFFFFF;
+  --card-foreground: #1A1A1A;
+  --popover: #FFFFFF;
+  --popover-foreground: #1A1A1A;
 
   /* サブテキスト */
-  --sub-text: oklch(0.50 0.04 260);
+  --sub-text: #666666;
 
   /* プライマリ */
-  --primary: oklch(0.20 0.04 260);
-  --primary-foreground: oklch(1 0 0);
+  --primary: #1A1A1A;
+  --primary-foreground: #FFFFFF;
 
   /* セカンダリ */
-  --secondary: oklch(0.97 0.01 240);
-  --secondary-foreground: oklch(0.20 0.04 260);
+  --secondary: #F3F4F6;
+  --secondary-foreground: #1A1A1A;
 
-  /* ミュート — chip/toolbar背景 */
-  --muted: oklch(0.97 0.01 240);
-  --muted-foreground: oklch(0.50 0.04 260);
+  /* ミュート */
+  --muted: #F3F4F6;
+  --muted-foreground: #999999;
 
-  /* アクセント — ブルー系 */
-  --accent: oklch(0.50 0.18 250);
-  --accent-foreground: oklch(1 0 0);
+  /* アクセント — ブルー */
+  --accent: #2563EB;
+  --accent-foreground: #FFFFFF;
 
   /* デストラクティブ */
-  --destructive: oklch(0.55 0.20 25);
+  --destructive: #E2483D;
 
   /* ボーダー・入力 */
-  --border: oklch(0.95 0.005 260);
-  --input: oklch(0.94 0.005 260);
-  --ring: oklch(0.50 0.18 250);
+  --border: #E5E7EB;
+  --input: #F3F4F6;
+  --ring: #2563EB;
 
   /* ドメインカラー */
-  --neon-green: oklch(0.45 0.16 155);
-  --neon-red: oklch(0.55 0.18 25);
-  --neon-cyan: oklch(0.50 0.18 250);
+  --neon-green: #2563EB;
+  --neon-red: #E2483D;
+  --neon-cyan: #2563EB;
 
   /* 担当者カラー */
-  --husband: oklch(0.50 0.18 250);
-  --husband-light: oklch(0.94 0.05 250);
-  --wife: oklch(0.55 0.18 350);
-  --wife-light: oklch(0.95 0.04 350);
+  --husband: #3B82F6;
+  --husband-light: #DBEAFE;
+  --wife: #EF4444;
+  --wife-light: #FEE2E2;
 
   /* シャドウ効果 */
-  --glow-accent: oklch(0.50 0.18 250);
-  --glow-sm: 0 1px 3px oklch(0 0 0 / 0.08);
-  --glow-md: 0 2px 8px oklch(0 0 0 / 0.10);
-  --glow-lg: 0 4px 16px oklch(0 0 0 / 0.12);
+  --glow-accent: #2563EB;
+  --glow-sm: 0 1px 3px #00000014;
+  --glow-md: 0 2px 8px #0000001A;
+  --glow-lg: 0 4px 16px #0000001F;
 
   /* Soft Cards シャドウ */
-  --shadow-soft: 0 4px 14px oklch(0.50 0.10 250 / 6%), 0 0 0 1px oklch(0.95 0.005 260);
-  --shadow-soft-lg: 0 8px 24px oklch(0.50 0.10 250 / 7%), 0 0 0 1px oklch(0.95 0.005 260);
-  --shadow-fab: 0 12px 24px oklch(0.55 0.18 255 / 28%);
+  --shadow-soft: 0 2px 8px #0000000D, 0 0 0 1px #E5E7EB;
+  --shadow-soft-lg: 0 4px 16px #0000000D, 0 0 0 1px #E5E7EB;
+  --shadow-fab: 0 4px 12px #2563EB33;
 
   /* カードシャドウ */
-  --shadow-card: 0 4px 14px oklch(0.50 0.10 250 / 6%), 0 0 0 1px oklch(0.95 0.005 260);
-  --shadow-card-hover: 0 8px 22px oklch(0.55 0.18 250 / 18%), 0 0 0 1.5px oklch(0.55 0.18 250);
-
-  /* グラデーション */
-  --gradient-hero-card: linear-gradient(160deg, oklch(0.97 0.025 235) 0%, oklch(0.99 0.01 240) 100%);
-  --gradient-fab: linear-gradient(160deg, oklch(0.55 0.18 255), oklch(0.48 0.20 265));
+  --shadow-card: 0 2px 8px #0000000D, 0 0 0 1px #E5E7EB;
+  --shadow-card-hover: 0 8px 22px #2563EB2E, 0 0 0 1.5px #2563EB;
 
   /* サーフェス */
-  --surface-chip: oklch(0.97 0.01 240);
-  --surface-total: oklch(0.99 0.005 240);
+  --surface-chip: #F3F4F6;
+  --surface-total: #FAFBFC;
 
   /* ドメインカラー（ライト版） */
-  --neon-green-light: oklch(0.94 0.08 155);
-  --neon-red-light: oklch(0.94 0.07 25);
-  --neon-cyan-light: oklch(0.94 0.05 250);
+  --neon-green-light: #EFF6FF;
+  --neon-red-light: #FFE8E6;
+  --neon-cyan-light: #EFF6FF;
 
-  /* 担当者グラデーション */
-  --gradient-husband: linear-gradient(135deg, oklch(0.65 0.16 250), oklch(0.55 0.18 260));
-  --gradient-wife: linear-gradient(135deg, oklch(0.75 0.16 350), oklch(0.65 0.18 20));
+  /* 担当者カラー（ソリッド） */
+  --gradient-husband: #3B82F6;
+  --gradient-wife: #EF4444;
 
   /* チャートバー（非カレント） */
-  --chart-bar-muted: oklch(0.88 0.01 260);
+  --chart-bar-muted: #E5E7EB;
 
   /* 警告カラー */
-  --warning: oklch(0.65 0.16 70);
+  --warning: #F59E0B;
 
   /* チャート */
-  --chart-1: oklch(0.55 0.18 250);
-  --chart-2: oklch(0.50 0.18 155);
-  --chart-3: oklch(0.50 0.18 250);
-  --chart-4: oklch(0.55 0.18 350);
-  --chart-5: oklch(0.50 0.20 25);
+  --chart-1: #2563EB;
+  --chart-2: #3B82F6;
+  --chart-3: #2563EB;
+  --chart-4: #EF4444;
+  --chart-5: #E2483D;
 
   /* サイドバー（互換性のため） */
-  --sidebar: oklch(0.97 0.01 260);
-  --sidebar-foreground: oklch(0.15 0.02 260);
-  --sidebar-primary: oklch(0.50 0.18 250);
-  --sidebar-primary-foreground: oklch(1 0 0);
-  --sidebar-accent: oklch(0.97 0.01 240);
-  --sidebar-accent-foreground: oklch(0.20 0.04 260);
-  --sidebar-border: oklch(0.95 0.005 260);
-  --sidebar-ring: oklch(0.50 0.18 250);
+  --sidebar: #F3F4F6;
+  --sidebar-foreground: #1A1A1A;
+  --sidebar-primary: #2563EB;
+  --sidebar-primary-foreground: #FFFFFF;
+  --sidebar-accent: #F3F4F6;
+  --sidebar-accent-foreground: #1A1A1A;
+  --sidebar-border: #E5E7EB;
+  --sidebar-ring: #2563EB;
 }
 
 /* ===== ダークモード ===== */
 .dark {
-  /* 背景系 — ダークネイビー */
-  --background: oklch(0.16 0.02 260);
-  --foreground: oklch(0.93 0.01 260);
-  --card: oklch(0.20 0.02 260);
-  --card-foreground: oklch(0.93 0.01 260);
-  --popover: oklch(0.20 0.02 260);
-  --popover-foreground: oklch(0.93 0.01 260);
+  /* 背景系 */
+  --background: #0F1117;
+  --foreground: #E5E7EB;
+  --card: #1A1D27;
+  --card-foreground: #E5E7EB;
+  --popover: #1A1D27;
+  --popover-foreground: #E5E7EB;
 
-  /* プライマリ — オフホワイト系 */
-  --primary: oklch(0.93 0.01 260);
-  --primary-foreground: oklch(0.16 0.02 260);
+  /* プライマリ */
+  --primary: #E5E7EB;
+  --primary-foreground: #0F1117;
 
-  /* セカンダリ — ダーク面 */
-  --secondary: oklch(0.25 0.02 260);
-  --secondary-foreground: oklch(0.93 0.01 260);
+  /* セカンダリ */
+  --secondary: #252833;
+  --secondary-foreground: #E5E7EB;
 
-  /* ミュート — 控えめな面 */
-  --muted: oklch(0.25 0.02 260);
-  --muted-foreground: oklch(0.60 0.02 260);
+  /* ミュート */
+  --muted: #252833;
+  --muted-foreground: #9CA3AF;
 
   /* アクセント — ブルー（ダーク版） */
-  --accent: oklch(0.70 0.18 250);
-  --accent-foreground: oklch(0.16 0.02 260);
+  --accent: #60A5FA;
+  --accent-foreground: #0F1117;
 
   /* デストラクティブ */
-  --destructive: oklch(0.70 0.20 25);
+  --destructive: #F87171;
 
   /* ボーダー・入力 */
-  --border: oklch(1 0 0 / 8%);
-  --input: oklch(1 0 0 / 12%);
-  --ring: oklch(0.70 0.18 250);
+  --border: #ffffff14;
+  --input: #ffffff1F;
+  --ring: #60A5FA;
 
-  /* サブテキスト — ダーク */
-  --sub-text: oklch(0.65 0.02 260);
+  /* サブテキスト */
+  --sub-text: #9CA3AF;
 
-  /* ドメインカラー — ネオンアクセント */
-  --neon-green: oklch(0.70 0.20 155);
-  --neon-red: oklch(0.70 0.20 25);
-  --neon-cyan: oklch(0.70 0.18 250);
+  /* ドメインカラー */
+  --neon-green: #60A5FA;
+  --neon-red: #F87171;
+  --neon-cyan: #60A5FA;
 
   /* 担当者カラー */
-  --husband: oklch(0.70 0.18 250);
-  --husband-light: oklch(0.70 0.18 250 / 15%);
-  --wife: oklch(0.72 0.18 350);
-  --wife-light: oklch(0.72 0.18 350 / 15%);
+  --husband: #60A5FA;
+  --husband-light: #60A5FA26;
+  --wife: #FB7185;
+  --wife-light: #FB718526;
 
   /* グロー効果（ダーク用） */
-  --glow-accent: oklch(0.70 0.18 250);
-  --glow-sm: 0 0 8px oklch(0.70 0.18 250 / 15%);
-  --glow-md: 0 0 16px oklch(0.70 0.18 250 / 20%);
-  --glow-lg: 0 0 24px oklch(0.70 0.18 250 / 25%);
+  --glow-accent: #60A5FA;
+  --glow-sm: 0 0 8px #60A5FA26;
+  --glow-md: 0 0 16px #60A5FA33;
+  --glow-lg: 0 0 24px #60A5FA40;
 
   /* Soft Cards シャドウ（ダーク用） */
-  --shadow-soft: 0 4px 14px oklch(0 0 0 / 0.3), 0 0 1px oklch(1 0 0 / 0.05);
-  --shadow-soft-lg: 0 8px 24px oklch(0 0 0 / 0.35), 0 0 1px oklch(1 0 0 / 0.08);
-  --shadow-fab: 0 12px 24px oklch(0.60 0.18 255 / 30%);
+  --shadow-soft: 0 4px 14px #0000004D, 0 0 1px #ffffff0D;
+  --shadow-soft-lg: 0 8px 24px #00000059, 0 0 1px #ffffff14;
+  --shadow-fab: 0 4px 12px #60A5FA4D;
 
   /* カードシャドウ（ダーク用） */
-  --shadow-card: 0 4px 14px oklch(0 0 0 / 0.3), 0 0 1px oklch(1 0 0 / 0.05);
-  --shadow-card-hover: 0 8px 22px oklch(0.70 0.18 250 / 18%), 0 0 1px oklch(1 0 0 / 0.08);
-
-  /* グラデーション（ダーク用） */
-  --gradient-hero-card: linear-gradient(160deg, oklch(0.22 0.03 250), oklch(0.18 0.02 260));
-  --gradient-fab: linear-gradient(160deg, oklch(0.60 0.18 255), oklch(0.55 0.20 265));
+  --shadow-card: 0 4px 14px #0000004D, 0 0 1px #ffffff0D;
+  --shadow-card-hover: 0 8px 22px #60A5FA2E, 0 0 1px #ffffff14;
 
   /* サーフェス（ダーク用） */
-  --surface-chip: oklch(0.25 0.02 260);
-  --surface-total: oklch(0.20 0.02 260);
+  --surface-chip: #252833;
+  --surface-total: #1A1D27;
 
   /* ドメインカラー（ダーク版） */
-  --neon-green-light: oklch(0.70 0.20 155 / 15%);
-  --neon-red-light: oklch(0.70 0.20 25 / 15%);
-  --neon-cyan-light: oklch(0.70 0.18 250 / 15%);
+  --neon-green-light: #60A5FA26;
+  --neon-red-light: #F8717126;
+  --neon-cyan-light: #60A5FA26;
 
-  /* 担当者グラデーション（ダーク版） */
-  --gradient-husband: linear-gradient(135deg, oklch(0.60 0.16 250), oklch(0.50 0.18 260));
-  --gradient-wife: linear-gradient(135deg, oklch(0.65 0.16 350), oklch(0.55 0.18 20));
+  /* 担当者カラー（ダーク版） */
+  --gradient-husband: #60A5FA;
+  --gradient-wife: #FB7185;
 
   /* チャートバー（非カレント・ダーク版） */
-  --chart-bar-muted: oklch(0.35 0.02 260);
+  --chart-bar-muted: #374151;
 
   /* 警告カラー */
-  --warning: oklch(0.75 0.16 70);
+  --warning: #FBBF24;
 
   /* チャート */
-  --chart-1: oklch(0.70 0.18 250);
-  --chart-2: oklch(0.75 0.20 155);
-  --chart-3: oklch(0.70 0.18 250);
-  --chart-4: oklch(0.72 0.18 350);
-  --chart-5: oklch(0.70 0.20 25);
+  --chart-1: #60A5FA;
+  --chart-2: #34D399;
+  --chart-3: #60A5FA;
+  --chart-4: #FB7185;
+  --chart-5: #F87171;
 
   /* サイドバー（互換性のため） */
-  --sidebar: oklch(0.18 0.02 260);
-  --sidebar-foreground: oklch(0.93 0.01 260);
-  --sidebar-primary: oklch(0.70 0.18 250);
-  --sidebar-primary-foreground: oklch(0.16 0.02 260);
-  --sidebar-accent: oklch(0.25 0.02 260);
-  --sidebar-accent-foreground: oklch(0.93 0.01 260);
-  --sidebar-border: oklch(1 0 0 / 8%);
-  --sidebar-ring: oklch(0.70 0.18 250);
+  --sidebar: #1A1D27;
+  --sidebar-foreground: #E5E7EB;
+  --sidebar-primary: #60A5FA;
+  --sidebar-primary-foreground: #0F1117;
+  --sidebar-accent: #252833;
+  --sidebar-accent-foreground: #E5E7EB;
+  --sidebar-border: #ffffff14;
+  --sidebar-ring: #60A5FA;
 }
 
 @layer base {
@@ -315,7 +307,7 @@
 }
 
 @utility gradient-fab {
-  background: var(--gradient-fab);
+  background: var(--accent);
 }
 
 @utility shadow-card {
@@ -329,7 +321,7 @@
 @utility card-interactive {
   transition: border-color 200ms ease, box-shadow 200ms ease, transform 200ms ease;
   &:hover {
-    border-color: oklch(from var(--accent) l c h / 30%);
+    border-color: color-mix(in srgb, var(--accent) 30%, transparent);
     box-shadow: var(--shadow-card-hover);
     transform: translateY(-1px);
   }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -53,6 +53,10 @@
   --color-husband-light: var(--husband-light);
   --color-wife: var(--wife);
   --color-wife-light: var(--wife-light);
+  --color-neon-green-light: var(--neon-green-light);
+  --color-neon-red-light: var(--neon-red-light);
+  --color-neon-cyan-light: var(--neon-cyan-light);
+  --color-chart-bar-muted: var(--chart-bar-muted);
   --color-warning: var(--warning);
   --color-sub-text: var(--sub-text);
 }
@@ -129,6 +133,18 @@
   /* サーフェス */
   --surface-chip: oklch(0.97 0.01 240);
   --surface-total: oklch(0.99 0.005 240);
+
+  /* ドメインカラー（ライト版） */
+  --neon-green-light: oklch(0.94 0.08 155);
+  --neon-red-light: oklch(0.94 0.07 25);
+  --neon-cyan-light: oklch(0.94 0.05 250);
+
+  /* 担当者グラデーション */
+  --gradient-husband: linear-gradient(135deg, oklch(0.65 0.16 250), oklch(0.55 0.18 260));
+  --gradient-wife: linear-gradient(135deg, oklch(0.75 0.16 350), oklch(0.65 0.18 20));
+
+  /* チャートバー（非カレント） */
+  --chart-bar-muted: oklch(0.88 0.01 260);
 
   /* 警告カラー */
   --warning: oklch(0.65 0.16 70);
@@ -221,6 +237,18 @@
   /* サーフェス（ダーク用） */
   --surface-chip: oklch(0.25 0.02 260);
   --surface-total: oklch(0.20 0.02 260);
+
+  /* ドメインカラー（ダーク版） */
+  --neon-green-light: oklch(0.70 0.20 155 / 15%);
+  --neon-red-light: oklch(0.70 0.20 25 / 15%);
+  --neon-cyan-light: oklch(0.70 0.18 250 / 15%);
+
+  /* 担当者グラデーション（ダーク版） */
+  --gradient-husband: linear-gradient(135deg, oklch(0.60 0.16 250), oklch(0.50 0.18 260));
+  --gradient-wife: linear-gradient(135deg, oklch(0.65 0.16 350), oklch(0.55 0.18 20));
+
+  /* チャートバー（非カレント・ダーク版） */
+  --chart-bar-muted: oklch(0.35 0.02 260);
 
   /* 警告カラー */
   --warning: oklch(0.75 0.16 70);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -61,74 +61,80 @@
 :root {
   --radius: 0.75rem;
 
-  /* 背景系 — ライト */
-  --background: oklch(0.99 0.005 260);
-  --foreground: oklch(0.13 0.02 260);
+  /* 背景系 — Soft Cards: 純白 */
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.20 0.04 260);
   --card: oklch(1 0 0);
-  --card-foreground: oklch(0.13 0.02 260);
+  --card-foreground: oklch(0.20 0.04 260);
   --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.13 0.02 260);
+  --popover-foreground: oklch(0.20 0.04 260);
 
   /* サブテキスト */
-  --sub-text: oklch(0.45 0.02 260);
+  --sub-text: oklch(0.50 0.04 260);
 
   /* プライマリ */
-  --primary: oklch(0.20 0.02 260);
-  --primary-foreground: oklch(0.99 0.005 260);
+  --primary: oklch(0.20 0.04 260);
+  --primary-foreground: oklch(1 0 0);
 
   /* セカンダリ */
-  --secondary: oklch(0.94 0.01 260);
-  --secondary-foreground: oklch(0.20 0.02 260);
+  --secondary: oklch(0.97 0.01 240);
+  --secondary-foreground: oklch(0.20 0.04 260);
 
-  /* ミュート */
-  --muted: oklch(0.94 0.01 260);
-  --muted-foreground: oklch(0.45 0.02 260);
+  /* ミュート — chip/toolbar背景 */
+  --muted: oklch(0.97 0.01 240);
+  --muted-foreground: oklch(0.50 0.04 260);
 
-  /* アクセント */
-  --accent: oklch(0.55 0.18 195);
+  /* アクセント — ブルー系 */
+  --accent: oklch(0.50 0.18 250);
   --accent-foreground: oklch(1 0 0);
 
   /* デストラクティブ */
-  --destructive: oklch(0.55 0.22 25);
+  --destructive: oklch(0.55 0.20 25);
 
   /* ボーダー・入力 */
-  --border: oklch(0.92 0.01 260);
-  --input: oklch(0.92 0.01 260);
-  --ring: oklch(0.50 0.16 195);
+  --border: oklch(0.95 0.005 260);
+  --input: oklch(0.94 0.005 260);
+  --ring: oklch(0.50 0.18 250);
 
   /* ドメインカラー */
-  --neon-green: oklch(0.45 0.18 155);
-  --neon-red: oklch(0.50 0.20 25);
-  --neon-cyan: oklch(0.50 0.16 195);
+  --neon-green: oklch(0.45 0.16 155);
+  --neon-red: oklch(0.55 0.18 25);
+  --neon-cyan: oklch(0.50 0.18 250);
 
   /* 担当者カラー */
   --husband: oklch(0.50 0.18 250);
-  --husband-light: oklch(0.50 0.18 250 / 10%);
+  --husband-light: oklch(0.94 0.05 250);
   --wife: oklch(0.55 0.18 350);
-  --wife-light: oklch(0.55 0.18 350 / 10%);
+  --wife-light: oklch(0.95 0.04 350);
 
-  /* シャドウ効果（ライト用） */
-  --glow-accent: oklch(0.55 0.18 195);
+  /* シャドウ効果 */
+  --glow-accent: oklch(0.50 0.18 250);
   --glow-sm: 0 1px 3px oklch(0 0 0 / 0.08);
   --glow-md: 0 2px 8px oklch(0 0 0 / 0.10);
   --glow-lg: 0 4px 16px oklch(0 0 0 / 0.12);
 
-  /* グラデーション背景 */
-  --gradient-page-from: oklch(0.99 0.005 260);
-  --gradient-page-to: oklch(0.98 0.01 260);
-  --gradient-hero-from: oklch(0.55 0.18 195 / 8%);
-  --gradient-hero-via: oklch(0.55 0.18 195 / 3%);
-  --gradient-hero-to: oklch(0.50 0.18 250 / 5%);
+  /* Soft Cards シャドウ */
+  --shadow-soft: 0 4px 14px oklch(0.50 0.10 250 / 6%), 0 0 0 1px oklch(0.95 0.005 260);
+  --shadow-soft-lg: 0 8px 24px oklch(0.50 0.10 250 / 7%), 0 0 0 1px oklch(0.95 0.005 260);
+  --shadow-fab: 0 12px 24px oklch(0.55 0.18 255 / 28%);
 
   /* カードシャドウ */
-  --shadow-card: 0 1px 3px oklch(0 0 0 / 0.06), 0 1px 2px oklch(0 0 0 / 0.04);
-  --shadow-card-hover: 0 4px 12px oklch(0 0 0 / 0.08), 0 2px 4px oklch(0 0 0 / 0.04);
+  --shadow-card: 0 4px 14px oklch(0.50 0.10 250 / 6%), 0 0 0 1px oklch(0.95 0.005 260);
+  --shadow-card-hover: 0 8px 22px oklch(0.55 0.18 250 / 18%), 0 0 0 1.5px oklch(0.55 0.18 250);
+
+  /* グラデーション */
+  --gradient-hero-card: linear-gradient(160deg, oklch(0.97 0.025 235) 0%, oklch(0.99 0.01 240) 100%);
+  --gradient-fab: linear-gradient(160deg, oklch(0.55 0.18 255), oklch(0.48 0.20 265));
+
+  /* サーフェス */
+  --surface-chip: oklch(0.97 0.01 240);
+  --surface-total: oklch(0.99 0.005 240);
 
   /* 警告カラー */
   --warning: oklch(0.65 0.16 70);
 
   /* チャート */
-  --chart-1: oklch(0.55 0.18 195);
+  --chart-1: oklch(0.55 0.18 250);
   --chart-2: oklch(0.50 0.18 155);
   --chart-3: oklch(0.50 0.18 250);
   --chart-4: oklch(0.55 0.18 350);
@@ -137,12 +143,12 @@
   /* サイドバー（互換性のため） */
   --sidebar: oklch(0.97 0.01 260);
   --sidebar-foreground: oklch(0.15 0.02 260);
-  --sidebar-primary: oklch(0.55 0.18 195);
+  --sidebar-primary: oklch(0.50 0.18 250);
   --sidebar-primary-foreground: oklch(1 0 0);
-  --sidebar-accent: oklch(0.94 0.01 260);
-  --sidebar-accent-foreground: oklch(0.20 0.02 260);
-  --sidebar-border: oklch(0.90 0.01 260);
-  --sidebar-ring: oklch(0.55 0.18 195);
+  --sidebar-accent: oklch(0.97 0.01 240);
+  --sidebar-accent-foreground: oklch(0.20 0.04 260);
+  --sidebar-border: oklch(0.95 0.005 260);
+  --sidebar-ring: oklch(0.50 0.18 250);
 }
 
 /* ===== ダークモード ===== */
@@ -167,8 +173,8 @@
   --muted: oklch(0.25 0.02 260);
   --muted-foreground: oklch(0.60 0.02 260);
 
-  /* アクセント — ネオンシアン（明度を微調整して目に優しく） */
-  --accent: oklch(0.72 0.16 195);
+  /* アクセント — ブルー（ダーク版） */
+  --accent: oklch(0.70 0.18 250);
   --accent-foreground: oklch(0.16 0.02 260);
 
   /* デストラクティブ */
@@ -177,7 +183,7 @@
   /* ボーダー・入力 */
   --border: oklch(1 0 0 / 8%);
   --input: oklch(1 0 0 / 12%);
-  --ring: oklch(0.72 0.16 195);
+  --ring: oklch(0.70 0.18 250);
 
   /* サブテキスト — ダーク */
   --sub-text: oklch(0.65 0.02 260);
@@ -185,7 +191,7 @@
   /* ドメインカラー — ネオンアクセント */
   --neon-green: oklch(0.70 0.20 155);
   --neon-red: oklch(0.70 0.20 25);
-  --neon-cyan: oklch(0.75 0.16 195);
+  --neon-cyan: oklch(0.70 0.18 250);
 
   /* 担当者カラー */
   --husband: oklch(0.70 0.18 250);
@@ -194,27 +200,33 @@
   --wife-light: oklch(0.72 0.18 350 / 15%);
 
   /* グロー効果（ダーク用） */
-  --glow-accent: oklch(0.72 0.16 195);
-  --glow-sm: 0 0 8px oklch(0.72 0.16 195 / 15%);
-  --glow-md: 0 0 16px oklch(0.72 0.16 195 / 20%);
-  --glow-lg: 0 0 24px oklch(0.72 0.16 195 / 25%);
+  --glow-accent: oklch(0.70 0.18 250);
+  --glow-sm: 0 0 8px oklch(0.70 0.18 250 / 15%);
+  --glow-md: 0 0 16px oklch(0.70 0.18 250 / 20%);
+  --glow-lg: 0 0 24px oklch(0.70 0.18 250 / 25%);
 
-  /* グラデーション背景（ダーク用） */
-  --gradient-page-from: oklch(0.16 0.02 260);
-  --gradient-page-to: oklch(0.14 0.03 230);
-  --gradient-hero-from: oklch(0.72 0.16 195 / 12%);
-  --gradient-hero-via: oklch(0.72 0.16 195 / 5%);
-  --gradient-hero-to: oklch(0.70 0.18 250 / 8%);
+  /* Soft Cards シャドウ（ダーク用） */
+  --shadow-soft: 0 4px 14px oklch(0 0 0 / 0.3), 0 0 1px oklch(1 0 0 / 0.05);
+  --shadow-soft-lg: 0 8px 24px oklch(0 0 0 / 0.35), 0 0 1px oklch(1 0 0 / 0.08);
+  --shadow-fab: 0 12px 24px oklch(0.60 0.18 255 / 30%);
 
   /* カードシャドウ（ダーク用） */
-  --shadow-card: 0 1px 3px oklch(0 0 0 / 0.3), 0 0 1px oklch(1 0 0 / 0.05);
-  --shadow-card-hover: 0 4px 16px oklch(0.72 0.16 195 / 15%), 0 0 1px oklch(1 0 0 / 0.08);
+  --shadow-card: 0 4px 14px oklch(0 0 0 / 0.3), 0 0 1px oklch(1 0 0 / 0.05);
+  --shadow-card-hover: 0 8px 22px oklch(0.70 0.18 250 / 18%), 0 0 1px oklch(1 0 0 / 0.08);
+
+  /* グラデーション（ダーク用） */
+  --gradient-hero-card: linear-gradient(160deg, oklch(0.22 0.03 250), oklch(0.18 0.02 260));
+  --gradient-fab: linear-gradient(160deg, oklch(0.60 0.18 255), oklch(0.55 0.20 265));
+
+  /* サーフェス（ダーク用） */
+  --surface-chip: oklch(0.25 0.02 260);
+  --surface-total: oklch(0.20 0.02 260);
 
   /* 警告カラー */
   --warning: oklch(0.75 0.16 70);
 
   /* チャート */
-  --chart-1: oklch(0.75 0.18 195);
+  --chart-1: oklch(0.70 0.18 250);
   --chart-2: oklch(0.75 0.20 155);
   --chart-3: oklch(0.70 0.18 250);
   --chart-4: oklch(0.72 0.18 350);
@@ -223,12 +235,12 @@
   /* サイドバー（互換性のため） */
   --sidebar: oklch(0.18 0.02 260);
   --sidebar-foreground: oklch(0.93 0.01 260);
-  --sidebar-primary: oklch(0.72 0.16 195);
+  --sidebar-primary: oklch(0.70 0.18 250);
   --sidebar-primary-foreground: oklch(0.16 0.02 260);
   --sidebar-accent: oklch(0.25 0.02 260);
   --sidebar-accent-foreground: oklch(0.93 0.01 260);
   --sidebar-border: oklch(1 0 0 / 8%);
-  --sidebar-ring: oklch(0.72 0.16 195);
+  --sidebar-ring: oklch(0.70 0.18 250);
 }
 
 @layer base {
@@ -258,20 +270,24 @@
   box-shadow: var(--glow-lg);
 }
 
-@utility glass {
-  background: oklch(from var(--card) l c h / 60%);
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
+@utility shadow-soft {
+  box-shadow: var(--shadow-soft);
 }
 
-@utility glass-strong {
-  background: oklch(from var(--card) l c h / 75%);
-  backdrop-filter: blur(20px) saturate(1.2);
-  -webkit-backdrop-filter: blur(20px) saturate(1.2);
+@utility shadow-soft-lg {
+  box-shadow: var(--shadow-soft-lg);
 }
 
-@utility gradient-page {
-  background: linear-gradient(135deg, var(--gradient-page-from), var(--gradient-page-to));
+@utility shadow-fab {
+  box-shadow: var(--shadow-fab);
+}
+
+@utility gradient-hero-card {
+  background: var(--gradient-hero-card);
+}
+
+@utility gradient-fab {
+  background: var(--gradient-fab);
 }
 
 @utility shadow-card {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,13 +1,14 @@
 import type { Metadata, Viewport } from 'next'
-import { Geist, Geist_Mono } from 'next/font/google'
+import { Inter } from 'next/font/google'
+import { Geist_Mono } from 'next/font/google'
 import { SpeedInsights } from '@vercel/speed-insights/next'
 import { Toaster } from '@/components/ui/sonner'
 import { ThemeProvider } from '@/components/providers/theme-provider'
 import { MotionProvider } from '@/components/animations/motion-provider'
 import './globals.css'
 
-const geistSans = Geist({
-  variable: '--font-geist-sans',
+const inter = Inter({
+  variable: '--font-inter',
   subsets: ['latin'],
 })
 
@@ -23,8 +24,8 @@ export const metadata: Metadata = {
 
 export const viewport: Viewport = {
   themeColor: [
-    { media: '(prefers-color-scheme: light)', color: 'oklch(0.97 0.01 260)' },
-    { media: '(prefers-color-scheme: dark)', color: 'oklch(0.16 0.02 260)' },
+    { media: '(prefers-color-scheme: light)', color: '#FAFBFC' },
+    { media: '(prefers-color-scheme: dark)', color: '#0F1117' },
   ],
 }
 
@@ -36,7 +37,7 @@ export default function RootLayout({
   return (
     <html lang="ja" suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${inter.variable} ${geistMono.variable} antialiased`}
       >
         <a
           href="#main"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,8 +23,9 @@ export const metadata: Metadata = {
 }
 
 export const viewport: Viewport = {
+  viewportFit: 'cover',
   themeColor: [
-    { media: '(prefers-color-scheme: light)', color: '#FAFBFC' },
+    { media: '(prefers-color-scheme: light)', color: '#4C3BCF' },
     { media: '(prefers-color-scheme: dark)', color: '#0F1117' },
   ],
 }

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -4,8 +4,8 @@ export default function Loading() {
   return (
     <div className="min-h-screen bg-background">
       {/* ヘッダー */}
-      <header className="sticky top-0 z-50 glass-strong border-b border-border/50">
-        <div className="container mx-auto px-4 py-3 flex items-center justify-between max-w-4xl">
+      <header className="sticky top-0 z-50 bg-background border-b border-border">
+        <div className="container mx-auto px-4 py-3.5 flex items-center justify-between max-w-4xl">
           <Skeleton className="h-4 w-28" />
           <div className="flex items-center gap-1">
             <Skeleton className="h-7 w-7 rounded-lg" />
@@ -27,16 +27,16 @@ export default function Loading() {
         </div>
 
         {/* ヒーロー / サマリー */}
-        <div className="py-5 border-y border-border">
+        <div className="rounded-[22px] shadow-soft-lg p-5">
           <Skeleton className="h-2.5 w-32" />
           <Skeleton className="h-10 w-48 mt-3" />
           <Skeleton className="h-3 w-56 mt-3" />
-          <div className="grid grid-cols-2 mt-4 border-t border-border">
-            <div className="py-3 pr-3.5 border-r border-border">
+          <div className="grid grid-cols-2 mt-4 gap-3">
+            <div className="rounded-[18px] shadow-soft p-4">
               <Skeleton className="h-2 w-12" />
               <Skeleton className="h-5 w-24 mt-2" />
             </div>
-            <div className="py-3 pl-3.5">
+            <div className="rounded-[18px] shadow-soft p-4">
               <Skeleton className="h-2 w-12" />
               <Skeleton className="h-5 w-24 mt-2" />
             </div>
@@ -50,11 +50,11 @@ export default function Loading() {
         </div>
 
         {/* リスト行 */}
-        <div className="border-t border-foreground/20">
+        <div className="rounded-[18px] shadow-soft overflow-hidden">
           {Array.from({ length: 6 }, (_, i) => (
             <div
               key={i}
-              className="grid grid-cols-[64px_1fr_auto] items-center gap-3.5 px-5 py-4 border-b border-border/60"
+              className="grid grid-cols-[32px_1fr_auto] items-center gap-3 px-3.5 py-3 border-b border-border last:border-b-0"
             >
               <Skeleton className="h-3 w-5" />
               <div className="space-y-1.5">

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -13,26 +13,23 @@ export default function LoginPage() {
     <div className="min-h-screen bg-background flex flex-col">
       {/* ヘッダー */}
       <header className="flex items-center justify-between px-5 py-3.5 border-b border-border">
-        <span className="text-[11px] font-bold tracking-[0.18em] uppercase">
+        <span className="text-[11px] font-bold tracking-[0.18em] uppercase text-sub-text">
           Score Splitter
         </span>
         <ThemeToggle />
       </header>
 
       {/* メイン */}
-      <main id="main" tabIndex={-1} className="flex-1 px-5 pt-14 pb-4 flex flex-col max-w-md mx-auto w-full">
+      <main id="main" tabIndex={-1} className="flex-1 px-5 pt-10 pb-4 flex flex-col max-w-md mx-auto w-full">
         {/* ヒーロー */}
-        <section className="pb-8 border-b border-border">
-          <div className="text-[10px] font-bold tracking-[0.22em] uppercase text-sub-text">
-            Sign in / ログイン
+        <section className="pb-6">
+          <div className="w-14 h-14 rounded-2xl gradient-fab text-white flex items-center justify-center shadow-fab">
+            <span className="text-2xl font-bold tracking-[-0.02em]">家</span>
           </div>
-          <div className="mt-3.5 w-14 h-14 rounded-xl bg-foreground flex items-center justify-center">
-            <span className="text-background text-2xl font-bold tracking-[-0.02em]">家</span>
-          </div>
-          <h1 className="text-[36px] font-bold tracking-[-0.04em] leading-[0.95] mt-4">
+          <h1 className="text-[28px] font-bold tracking-[-0.03em] leading-[1.05] mt-4">
             家計計算アプリ
           </h1>
-          <p className="text-[13px] text-sub-text mt-3 leading-relaxed">
+          <p className="text-[13px] text-sub-text mt-2.5 leading-relaxed">
             パスワードを入力してログインしてください。
             <br />
             セッションは7日間保持されます。
@@ -40,64 +37,68 @@ export default function LoginPage() {
         </section>
 
         {/* パスワードフォーム */}
-        <form action={formAction} className="pt-8 flex flex-col gap-3.5">
-          <div className="flex items-baseline justify-between">
-            <label
-              htmlFor="password"
-              className="text-[10px] font-bold tracking-[0.2em] uppercase text-sub-text"
-            >
-              パスワード
-            </label>
-            <span className="text-[10px] text-sub-text font-tabular tracking-[0.06em]">
-              {showPassword ? 'visible' : 'hidden'}
-            </span>
-          </div>
+        <div className="rounded-[20px] shadow-soft-lg p-[18px]">
+          <form action={formAction} className="flex flex-col gap-3.5">
+            <div>
+              <div className="flex items-baseline justify-between mb-2">
+                <label
+                  htmlFor="password"
+                  className="text-[11px] font-bold tracking-[0.14em] uppercase text-sub-text"
+                >
+                  パスワード
+                </label>
+                <span className="text-[10px] text-sub-text font-tabular">
+                  {showPassword ? 'visible' : 'hidden'}
+                </span>
+              </div>
 
-          <div className="border-b-[1.5px] border-foreground flex items-center pb-2.5">
-            <input
-              id="password"
-              type={showPassword ? 'text' : 'password'}
-              name="password"
-              placeholder="パスワード"
-              required
-              autoFocus
-              className="flex-1 text-[26px] font-medium tracking-[0.32em] bg-transparent border-none outline-none font-tabular placeholder:text-muted-foreground/40 placeholder:tracking-normal placeholder:text-base"
-            />
-            <button
-              type="button"
-              onClick={() => setShowPassword((prev) => !prev)}
-              className="text-[11px] font-bold tracking-[0.14em] uppercase text-sub-text hover:text-foreground transition-colors shrink-0"
-            >
-              {showPassword ? '隠す' : '表示'}
-            </button>
-          </div>
-
-          {state.error && (
-            <div className="flex items-center gap-2 mt-1">
-              <span className="w-1.5 h-1.5 rounded-full bg-destructive shrink-0" />
-              <span className="text-[12px] font-semibold text-destructive">{state.error}</span>
+              <div className="rounded-[14px] bg-[oklch(0.98_0.005_260)] dark:bg-muted border border-input flex items-center px-4 py-3.5">
+                <input
+                  id="password"
+                  type={showPassword ? 'text' : 'password'}
+                  name="password"
+                  placeholder="パスワード"
+                  required
+                  autoFocus
+                  className="flex-1 text-[20px] font-semibold tracking-[0.30em] bg-transparent border-none outline-none font-tabular placeholder:text-muted-foreground/40 placeholder:tracking-normal placeholder:text-base"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword((prev) => !prev)}
+                  className="text-[11px] font-bold tracking-[0.10em] uppercase text-accent shrink-0"
+                >
+                  {showPassword ? '隠す' : '表示'}
+                </button>
+              </div>
             </div>
-          )}
 
-          <button
-            type="submit"
-            disabled={isPending}
-            className="mt-3.5 py-[18px] px-4 bg-foreground text-background rounded-xl text-[13px] font-bold tracking-[0.18em] uppercase flex items-center justify-between disabled:opacity-50 transition-opacity"
-          >
-            <span>{isPending ? 'ログイン中…' : 'ログイン'}</span>
-            {!isPending && <span className="text-lg font-normal">→</span>}
-          </button>
-        </form>
+            {state.error && (
+              <div className="flex items-center gap-2">
+                <span className="w-1.5 h-1.5 rounded-full bg-destructive shrink-0" />
+                <span className="text-[12px] font-semibold text-destructive">{state.error}</span>
+              </div>
+            )}
+
+            <button
+              type="submit"
+              disabled={isPending}
+              className="mt-1 py-4 px-5 gradient-fab text-white rounded-full text-[13px] font-bold tracking-[0.14em] uppercase flex items-center justify-between shadow-fab disabled:opacity-50 transition-opacity"
+            >
+              <span>{isPending ? 'ログイン中…' : 'ログイン'}</span>
+              {!isPending && <span className="text-lg font-normal">→</span>}
+            </button>
+          </form>
+        </div>
       </main>
 
       {/* フッター */}
-      <footer className="px-5 py-5 border-t border-border flex items-baseline justify-between">
+      <footer className="px-5 py-5 flex items-baseline justify-between">
         <p className="text-[11px] text-sub-text leading-relaxed">
           パスワードを忘れた場合は
           <br />
           管理者に問い合わせてください。
         </p>
-        <span className="text-[10px] font-bold tracking-[0.16em] uppercase shrink-0">
+        <span className="text-[11px] font-bold tracking-[0.12em] uppercase text-accent shrink-0">
           Help ›
         </span>
       </footer>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -52,7 +52,7 @@ export default function LoginPage() {
                 </span>
               </div>
 
-              <div className="rounded-[14px] bg-[oklch(0.98_0.005_260)] dark:bg-muted border border-input flex items-center px-4 py-3.5">
+              <div className="rounded-[14px] bg-secondary dark:bg-muted border border-input flex items-center px-4 py-3.5">
                 <input
                   id="password"
                   type={showPassword ? 'text' : 'password'}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -23,13 +23,13 @@ export default function LoginPage() {
       <main id="main" tabIndex={-1} className="flex-1 px-5 pt-10 pb-4 flex flex-col max-w-md mx-auto w-full">
         {/* ヒーロー */}
         <section className="pb-6">
-          <div className="w-14 h-14 rounded-2xl gradient-fab text-white flex items-center justify-center shadow-fab">
-            <span className="text-2xl font-bold tracking-[-0.02em]">家</span>
+          <div className="w-12 h-12 rounded-[12px] bg-[#2563EB] text-white flex items-center justify-center">
+            <span className="text-[22px] font-bold">家</span>
           </div>
-          <h1 className="text-[28px] font-bold tracking-[-0.03em] leading-[1.05] mt-4">
+          <h1 className="text-[22px] font-bold tracking-[-0.03em] leading-[1.05] mt-4">
             家計計算アプリ
           </h1>
-          <p className="text-[13px] text-sub-text mt-2.5 leading-relaxed">
+          <p className="text-[13px] text-[#666666] mt-2.5 leading-relaxed text-center">
             パスワードを入力してログインしてください。
             <br />
             セッションは7日間保持されます。
@@ -52,7 +52,7 @@ export default function LoginPage() {
                 </span>
               </div>
 
-              <div className="rounded-[14px] bg-secondary dark:bg-muted border border-input flex items-center px-4 py-3.5">
+              <div className="rounded-[12px] bg-[#F3F4F6] flex items-center px-4 h-12">
                 <input
                   id="password"
                   type={showPassword ? 'text' : 'password'}
@@ -82,7 +82,7 @@ export default function LoginPage() {
             <button
               type="submit"
               disabled={isPending}
-              className="mt-1 py-4 px-5 gradient-fab text-white rounded-full text-[13px] font-bold tracking-[0.14em] uppercase flex items-center justify-between shadow-fab disabled:opacity-50 transition-opacity"
+              className="mt-1 h-12 px-5 bg-[#2563EB] text-white rounded-[12px] text-[13px] font-bold tracking-[0.14em] uppercase flex items-center justify-between shadow-[0_4px_12px_#2563EB33] disabled:opacity-50 transition-opacity"
             >
               <span>{isPending ? 'ログイン中…' : 'ログイン'}</span>
               {!isPending && <span className="text-lg font-normal">→</span>}
@@ -98,7 +98,7 @@ export default function LoginPage() {
           <br />
           管理者に問い合わせてください。
         </p>
-        <span className="text-[11px] font-bold tracking-[0.12em] uppercase text-accent shrink-0">
+        <span className="text-[11px] font-bold tracking-[0.12em] uppercase text-[#2563EB] shrink-0">
           Help ›
         </span>
       </footer>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,10 @@
 import { redirect } from 'next/navigation'
 import { Header } from '@/components/layout/header'
-import { MonthToolbar } from '@/components/layout/month-toolbar'
+import { HeroSection } from '@/components/sections/hero-section'
+import { TrendCard } from '@/components/charts/trend-card'
 import { IncomeSection } from '@/components/sections/income-section'
 import { ExpenseSection } from '@/components/sections/expense-section'
 import { CarryoverSection } from '@/components/sections/carryover-section'
-import { CalculationSection } from '@/components/sections/calculation-section'
 import { MonthlyListSection } from '@/components/sections/monthly-list-section'
 import { getIncomesByMonth } from '@/app/actions/income'
 import { getExpensesByMonth } from '@/app/actions/expense'
@@ -37,7 +37,7 @@ export default async function HomePage({ searchParams }: HomeProps) {
         <main
           id="main"
           tabIndex={-1}
-          className="container mx-auto px-4 py-5 space-y-4 max-w-4xl"
+          className="px-5 py-5 space-y-6 max-w-4xl mx-auto"
         >
           <MonthlyListSection summaries={summaries} />
         </main>
@@ -67,20 +67,17 @@ export default async function HomePage({ searchParams }: HomeProps) {
 
   return (
     <div className="min-h-screen bg-background">
-      <Header currentMonth={month} />
-      <main id="main" tabIndex={-1} className="container mx-auto px-4 py-5 space-y-4 max-w-4xl">
-        <MonthToolbar currentMonth={month} incomes={incomes} expenses={expenses} carryovers={carryovers} />
-        <CalculationSection
-          incomes={incomes}
-          expenses={expenses}
-          carryovers={carryovers}
-          currentMonth={month}
-          recentSummaries={recentSummaries}
-        />
-        <section className="grid gap-4 md:gap-5 md:grid-cols-2">
-          <IncomeSection incomes={incomes} month={month} />
-          <ExpenseSection expenses={expenses} month={month} />
-        </section>
+      <HeroSection
+        currentMonth={month}
+        incomes={incomes}
+        expenses={expenses}
+        carryovers={carryovers}
+        recentSummaries={recentSummaries}
+      />
+      <main id="main" tabIndex={-1} className="px-5 pt-2 pb-8 space-y-4 max-w-4xl mx-auto">
+        <TrendCard summaries={recentSummaries} currentMonth={month} />
+        <IncomeSection incomes={incomes} month={month} />
+        <ExpenseSection expenses={expenses} month={month} />
         <CarryoverSection carryovers={carryovers} month={month} />
       </main>
       <AddEntryFab month={month} />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -73,9 +73,10 @@ export default async function HomePage({ searchParams }: HomeProps) {
         expenses={expenses}
         carryovers={carryovers}
         recentSummaries={recentSummaries}
-      />
-      <main id="main" tabIndex={-1} className="px-5 pt-2 pb-8 space-y-4 max-w-4xl mx-auto">
+      >
         <TrendCard summaries={recentSummaries} currentMonth={month} />
+      </HeroSection>
+      <main id="main" tabIndex={-1} className="px-5 pt-2 pb-8 space-y-4 max-w-4xl mx-auto">
         <IncomeSection incomes={incomes} month={month} />
         <ExpenseSection expenses={expenses} month={month} />
         <CarryoverSection carryovers={carryovers} month={month} />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -37,7 +37,7 @@ export default async function HomePage({ searchParams }: HomeProps) {
         <main
           id="main"
           tabIndex={-1}
-          className="container mx-auto px-4 py-4 space-y-0 max-w-4xl"
+          className="container mx-auto px-4 py-5 space-y-4 max-w-4xl"
         >
           <MonthlyListSection summaries={summaries} />
         </main>
@@ -68,7 +68,7 @@ export default async function HomePage({ searchParams }: HomeProps) {
   return (
     <div className="min-h-screen bg-background">
       <Header currentMonth={month} />
-      <main id="main" tabIndex={-1} className="container mx-auto px-4 py-4 space-y-0 max-w-4xl">
+      <main id="main" tabIndex={-1} className="container mx-auto px-4 py-5 space-y-4 max-w-4xl">
         <MonthToolbar currentMonth={month} incomes={incomes} expenses={expenses} carryovers={carryovers} />
         <CalculationSection
           incomes={incomes}
@@ -77,7 +77,7 @@ export default async function HomePage({ searchParams }: HomeProps) {
           currentMonth={month}
           recentSummaries={recentSummaries}
         />
-        <section className="py-8 md:py-10 md:px-6 grid gap-8 md:gap-16 md:grid-cols-2">
+        <section className="grid gap-4 md:gap-5 md:grid-cols-2">
           <IncomeSection incomes={incomes} month={month} />
           <ExpenseSection expenses={expenses} month={month} />
         </section>

--- a/src/components/charts/mini-bar-chart.tsx
+++ b/src/components/charts/mini-bar-chart.tsx
@@ -43,8 +43,8 @@ export function MiniBarChart({ summaries, currentMonth }: MiniBarChartProps) {
                 backgroundColor: isCurrent
                   ? 'var(--neon-green)'
                   : isPositive
-                    ? 'oklch(0.88 0.01 260)'
-                    : 'oklch(0.50 0.20 25 / 30%)',
+                    ? 'var(--chart-bar-muted)'
+                    : 'var(--neon-red-light)',
               }}
               initial={{ height: 0 }}
               animate={{ height: `${heightPct}%` }}

--- a/src/components/charts/trend-card.tsx
+++ b/src/components/charts/trend-card.tsx
@@ -22,24 +22,24 @@ export function TrendCard({ summaries, currentMonth }: TrendCardProps) {
   }, 1)
 
   return (
-    <div className="rounded-[16px] bg-white p-4 shadow-soft">
+    <div className="rounded-[16px] bg-card p-4 shadow-soft">
       <div className="flex items-center justify-between">
-        <span className="text-[11px] font-semibold tracking-[0.8px] text-[#999999] uppercase">
+        <span className="text-[11px] font-semibold tracking-[0.8px] text-muted-foreground uppercase">
           Trend / 推移
         </span>
-        <span className="text-[10px] font-medium text-[#999999]">
+        <span className="text-[10px] font-medium text-muted-foreground">
           直近{summaries.length}ヶ月
         </span>
       </div>
 
       <div className="flex items-center justify-center gap-3 mt-2">
         <div className="flex items-center gap-1">
-          <div className="w-1.5 h-1.5 rounded-full bg-[#3B82F6]" />
-          <span className="text-[9px] text-[#666666]">収入</span>
+          <div className="w-1.5 h-1.5 rounded-full bg-husband" />
+          <span className="text-[9px] text-sub-text">収入</span>
         </div>
         <div className="flex items-center gap-1">
-          <div className="w-1.5 h-1.5 rounded-full bg-[#EF4444]" />
-          <span className="text-[9px] text-[#666666]">支出</span>
+          <div className="w-1.5 h-1.5 rounded-full bg-wife" />
+          <span className="text-[9px] text-sub-text">支出</span>
         </div>
       </div>
 
@@ -53,20 +53,19 @@ export function TrendCard({ summaries, currentMonth }: TrendCardProps) {
             <div key={s.month} className="flex-1 flex flex-col items-center gap-1 min-w-0">
               <div className="flex items-end gap-[3px] h-[84px] w-full justify-center">
                 <motion.div
-                  className="w-2 rounded-t-[3px]"
-                  style={{ backgroundColor: isCurrent ? '#2563EB' : '#3B82F6' }}
+                  className={`w-2 rounded-t-[3px] ${isCurrent ? 'bg-accent' : 'bg-husband'}`}
                   initial={{ height: 0 }}
                   animate={{ height: `${incomeH}%` }}
                   transition={barSpring}
                 />
                 <motion.div
-                  className="w-2 rounded-t-[3px] bg-[#EF4444]"
+                  className="w-2 rounded-t-[3px] bg-wife"
                   initial={{ height: 0 }}
                   animate={{ height: `${expenseH}%` }}
                   transition={barSpring}
                 />
               </div>
-              <span className={`text-[8px] font-mono ${isCurrent ? 'text-[#2563EB] font-bold' : 'text-[#999999]'}`}>
+              <span className={`text-[8px] font-mono ${isCurrent ? 'text-accent font-bold' : 'text-muted-foreground'}`}>
                 {formatShortMonth(s.month)}
               </span>
             </div>

--- a/src/components/charts/trend-card.tsx
+++ b/src/components/charts/trend-card.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import { motion } from 'motion/react'
+import { barSpring } from '@/components/animations/tokens'
+import type { MonthlySummary } from '@/types'
+
+interface TrendCardProps {
+  summaries: MonthlySummary[]
+  currentMonth: string
+}
+
+function formatShortMonth(month: string): string {
+  const m = parseInt(month.slice(4, 6), 10)
+  return `${m}月`
+}
+
+export function TrendCard({ summaries, currentMonth }: TrendCardProps) {
+  if (summaries.length === 0) return null
+
+  const maxVal = summaries.reduce((max, s) => {
+    return Math.max(max, s.incomeTotal, Math.abs(s.expenseTotal))
+  }, 1)
+
+  return (
+    <div className="rounded-[16px] bg-white p-4 shadow-soft">
+      <div className="flex items-center justify-between">
+        <span className="text-[11px] font-semibold tracking-[0.8px] text-[#999999] uppercase">
+          Trend / 推移
+        </span>
+        <span className="text-[10px] font-medium text-[#999999]">
+          直近{summaries.length}ヶ月
+        </span>
+      </div>
+
+      <div className="flex items-center justify-center gap-3 mt-2">
+        <div className="flex items-center gap-1">
+          <div className="w-1.5 h-1.5 rounded-full bg-[#3B82F6]" />
+          <span className="text-[9px] text-[#666666]">収入</span>
+        </div>
+        <div className="flex items-center gap-1">
+          <div className="w-1.5 h-1.5 rounded-full bg-[#EF4444]" />
+          <span className="text-[9px] text-[#666666]">支出</span>
+        </div>
+      </div>
+
+      <div className="flex items-end gap-1.5 h-[100px] mt-3 px-2">
+        {summaries.map((s) => {
+          const incomeH = (s.incomeTotal / maxVal) * 100
+          const expenseH = (Math.abs(s.expenseTotal) / maxVal) * 100
+          const isCurrent = s.month === currentMonth
+
+          return (
+            <div key={s.month} className="flex-1 flex flex-col items-center gap-1">
+              <div className="flex items-end gap-[3px] h-full w-full justify-center">
+                <motion.div
+                  className="w-2 rounded-t-[3px]"
+                  style={{ backgroundColor: isCurrent ? '#2563EB' : '#3B82F6' }}
+                  initial={{ height: 0 }}
+                  animate={{ height: `${incomeH}%` }}
+                  transition={barSpring}
+                />
+                <motion.div
+                  className="w-2 rounded-t-[3px] bg-[#EF4444]"
+                  initial={{ height: 0 }}
+                  animate={{ height: `${expenseH}%` }}
+                  transition={barSpring}
+                />
+              </div>
+              <span className={`text-[8px] font-mono ${isCurrent ? 'text-[#2563EB] font-bold' : 'text-[#999999]'}`}>
+                {formatShortMonth(s.month)}
+              </span>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/components/charts/trend-card.tsx
+++ b/src/components/charts/trend-card.tsx
@@ -50,8 +50,8 @@ export function TrendCard({ summaries, currentMonth }: TrendCardProps) {
           const isCurrent = s.month === currentMonth
 
           return (
-            <div key={s.month} className="flex-1 flex flex-col items-center gap-1">
-              <div className="flex items-end gap-[3px] h-full w-full justify-center">
+            <div key={s.month} className="flex-1 flex flex-col items-center gap-1 min-w-0">
+              <div className="flex items-end gap-[3px] h-[84px] w-full justify-center">
                 <motion.div
                   className="w-2 rounded-t-[3px]"
                   style={{ backgroundColor: isCurrent ? '#2563EB' : '#3B82F6' }}

--- a/src/components/charts/yearly-bar-chart.tsx
+++ b/src/components/charts/yearly-bar-chart.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import { motion } from 'motion/react'
+import { barSpring } from '@/components/animations/tokens'
+import type { MonthlySummary } from '@/types'
+
+interface YearlyBarChartProps {
+  summaries: MonthlySummary[]
+  year: number
+}
+
+export function YearlyBarChart({ summaries, year }: YearlyBarChartProps) {
+  const summaryMap = new Map(summaries.map((s) => [s.month, s]))
+
+  const maxVal = summaries.reduce((max, s) => {
+    return Math.max(max, Math.abs(s.balance))
+  }, 1)
+
+  const months = Array.from({ length: 12 }, (_, i) => {
+    const monthStr = `${year}${String(i + 1).padStart(2, '0')}`
+    return { month: monthStr, label: String(i + 1), summary: summaryMap.get(monthStr) }
+  })
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <span className="text-[10px] font-medium text-[#999999]">
+          月次推移 / 1月〜12月
+        </span>
+        <div className="flex items-center gap-1">
+          <div className="w-1.5 h-1.5 rounded-full bg-[#2563EB]" />
+          <div className="w-1.5 h-1.5 rounded-full bg-[#E2483D]" />
+        </div>
+      </div>
+
+      <div className="flex items-end gap-1 h-[80px]">
+        {months.map(({ month, summary }) => {
+          if (!summary) {
+            return (
+              <div key={month} className="flex-1 flex items-end justify-center">
+                <div className="w-full rounded-sm bg-[#E5E7EB] h-2" />
+              </div>
+            )
+          }
+
+          const h = (Math.abs(summary.balance) / maxVal) * 100
+          const isPositive = summary.balance >= 0
+
+          return (
+            <div key={month} className="flex-1 flex items-end justify-center">
+              <motion.div
+                className="w-full rounded-sm"
+                style={{ backgroundColor: isPositive ? '#2563EB' : '#E2483D' }}
+                initial={{ height: 0 }}
+                animate={{ height: `${Math.max(h, 5)}%` }}
+                transition={barSpring}
+              />
+            </div>
+          )
+        })}
+      </div>
+
+      <div className="flex gap-1">
+        {months.map(({ month, label }) => (
+          <span
+            key={month}
+            className="flex-1 text-center text-[8px] font-mono font-medium text-[#999999]"
+          >
+            {label}
+          </span>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/charts/yearly-bar-chart.tsx
+++ b/src/components/charts/yearly-bar-chart.tsx
@@ -33,26 +33,26 @@ export function YearlyBarChart({ summaries, year }: YearlyBarChartProps) {
         </div>
       </div>
 
-      <div className="flex items-end gap-1 h-[80px]">
+      <div className="flex items-end gap-1">
         {months.map(({ month, summary }) => {
           if (!summary) {
             return (
-              <div key={month} className="flex-1 flex items-end justify-center">
+              <div key={month} className="flex-1 flex items-end justify-center h-[80px]">
                 <div className="w-full rounded-sm bg-[#E5E7EB] h-2" />
               </div>
             )
           }
 
-          const h = (Math.abs(summary.balance) / maxVal) * 100
+          const h = Math.max((Math.abs(summary.balance) / maxVal) * 80, 4)
           const isPositive = summary.balance >= 0
 
           return (
-            <div key={month} className="flex-1 flex items-end justify-center">
+            <div key={month} className="flex-1 flex items-end justify-center h-[80px]">
               <motion.div
                 className="w-full rounded-sm"
                 style={{ backgroundColor: isPositive ? '#2563EB' : '#E2483D' }}
                 initial={{ height: 0 }}
-                animate={{ height: `${Math.max(h, 5)}%` }}
+                animate={{ height: h }}
                 transition={barSpring}
               />
             </div>

--- a/src/components/charts/yearly-bar-chart.tsx
+++ b/src/components/charts/yearly-bar-chart.tsx
@@ -24,12 +24,12 @@ export function YearlyBarChart({ summaries, year }: YearlyBarChartProps) {
   return (
     <div className="flex flex-col gap-2">
       <div className="flex items-center justify-between">
-        <span className="text-[10px] font-medium text-[#999999]">
+        <span className="text-[10px] font-medium text-muted-foreground">
           月次推移 / 1月〜12月
         </span>
         <div className="flex items-center gap-1">
-          <div className="w-1.5 h-1.5 rounded-full bg-[#2563EB]" />
-          <div className="w-1.5 h-1.5 rounded-full bg-[#E2483D]" />
+          <div className="w-1.5 h-1.5 rounded-full bg-accent" />
+          <div className="w-1.5 h-1.5 rounded-full bg-destructive" />
         </div>
       </div>
 
@@ -38,7 +38,7 @@ export function YearlyBarChart({ summaries, year }: YearlyBarChartProps) {
           if (!summary) {
             return (
               <div key={month} className="flex-1 flex items-end justify-center h-[80px]">
-                <div className="w-full rounded-sm bg-[#E5E7EB] h-2" />
+                <div className="w-full rounded-sm bg-chart-bar-muted h-2" />
               </div>
             )
           }
@@ -49,8 +49,7 @@ export function YearlyBarChart({ summaries, year }: YearlyBarChartProps) {
           return (
             <div key={month} className="flex-1 flex items-end justify-center h-[80px]">
               <motion.div
-                className="w-full rounded-sm"
-                style={{ backgroundColor: isPositive ? '#2563EB' : '#E2483D' }}
+                className={`w-full rounded-sm ${isPositive ? 'bg-accent' : 'bg-destructive'}`}
                 initial={{ height: 0 }}
                 animate={{ height: h }}
                 transition={barSpring}
@@ -64,7 +63,7 @@ export function YearlyBarChart({ summaries, year }: YearlyBarChartProps) {
         {months.map(({ month, label }) => (
           <span
             key={month}
-            className="flex-1 text-center text-[8px] font-mono font-medium text-[#999999]"
+            className="flex-1 text-center text-[8px] font-mono font-medium text-muted-foreground"
           >
             {label}
           </span>

--- a/src/components/features/add-entry-fab.tsx
+++ b/src/components/features/add-entry-fab.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useState } from 'react'
-import { Plus } from 'lucide-react'
 import { AddEntrySheet } from '@/components/features/add-entry-sheet'
 
 interface AddEntryFabProps {
@@ -17,12 +16,10 @@ export function AddEntryFab({ month }: AddEntryFabProps) {
         type="button"
         onClick={() => setOpen(true)}
         aria-label="項目を追加"
-        className="fixed right-4 bottom-5 z-40 md:hidden rounded-full gradient-fab text-white px-5 py-3.5 shadow-fab flex items-center gap-2.5 active:scale-95 transition-transform"
+        className="fixed right-4 bottom-5 z-40 md:hidden rounded-full bg-[#2563EB] text-white px-5 py-3.5 shadow-[0_4px_12px_#2563EB33] flex items-center gap-1.5 active:scale-95 transition-transform"
       >
-        <span className="w-[30px] h-[30px] rounded-full bg-white/20 flex items-center justify-center">
-          <Plus className="h-4 w-4" />
-        </span>
-        <span className="text-sm font-bold">項目を追加</span>
+        <span className="text-base font-semibold">+</span>
+        <span className="text-[13px] font-semibold">項目を追加</span>
       </button>
       <AddEntrySheet open={open} onOpenChange={setOpen} month={month} />
     </>

--- a/src/components/features/add-entry-fab.tsx
+++ b/src/components/features/add-entry-fab.tsx
@@ -17,9 +17,12 @@ export function AddEntryFab({ month }: AddEntryFabProps) {
         type="button"
         onClick={() => setOpen(true)}
         aria-label="項目を追加"
-        className="fixed right-4 bottom-4 z-40 md:hidden w-[52px] h-[52px] rounded-full bg-foreground text-background flex items-center justify-center shadow-lg active:scale-95 transition-transform"
+        className="fixed right-4 bottom-5 z-40 md:hidden rounded-full gradient-fab text-white px-5 py-3.5 shadow-fab flex items-center gap-2.5 active:scale-95 transition-transform"
       >
-        <Plus className="h-5 w-5" />
+        <span className="w-[30px] h-[30px] rounded-full bg-white/20 flex items-center justify-center">
+          <Plus className="h-4 w-4" />
+        </span>
+        <span className="text-sm font-bold">項目を追加</span>
       </button>
       <AddEntrySheet open={open} onOpenChange={setOpen} month={month} />
     </>

--- a/src/components/features/add-entry-sheet.tsx
+++ b/src/components/features/add-entry-sheet.tsx
@@ -27,21 +27,21 @@ interface AddEntrySheetProps {
 const typeConfig = {
   income: {
     label: '収入',
-    bg: 'oklch(0.94 0.08 155)',
-    fg: 'oklch(0.42 0.16 155)',
-    border: 'oklch(0.65 0.16 155)',
+    bg: 'var(--neon-green-light)',
+    fg: 'var(--neon-green)',
+    border: 'var(--neon-green)',
   },
   expense: {
     label: '支出',
-    bg: 'oklch(0.94 0.07 25)',
-    fg: 'oklch(0.50 0.18 25)',
-    border: 'oklch(0.70 0.16 25)',
+    bg: 'var(--neon-red-light)',
+    fg: 'var(--neon-red)',
+    border: 'var(--neon-red)',
   },
   carryover: {
     label: '繰越',
-    bg: 'oklch(0.94 0.05 250)',
-    fg: 'oklch(0.45 0.18 250)',
-    border: 'oklch(0.65 0.16 250)',
+    bg: 'var(--neon-cyan-light)',
+    fg: 'var(--neon-cyan)',
+    border: 'var(--neon-cyan)',
   },
 } as const
 

--- a/src/components/features/add-entry-sheet.tsx
+++ b/src/components/features/add-entry-sheet.tsx
@@ -27,21 +27,21 @@ interface AddEntrySheetProps {
 const typeConfig = {
   income: {
     label: '収入',
-    bg: 'oklch(0.45 0.18 155 / 12%)',
-    fg: 'oklch(0.42 0.18 155)',
-    border: 'oklch(0.45 0.18 155 / 30%)',
+    bg: 'oklch(0.94 0.08 155)',
+    fg: 'oklch(0.42 0.16 155)',
+    border: 'oklch(0.65 0.16 155)',
   },
   expense: {
     label: '支出',
-    bg: 'oklch(0.50 0.20 25 / 12%)',
-    fg: 'oklch(0.50 0.20 25)',
-    border: 'oklch(0.50 0.20 25 / 30%)',
+    bg: 'oklch(0.94 0.07 25)',
+    fg: 'oklch(0.50 0.18 25)',
+    border: 'oklch(0.70 0.16 25)',
   },
   carryover: {
     label: '繰越',
-    bg: 'oklch(0.50 0.16 195 / 12%)',
-    fg: 'oklch(0.45 0.16 195)',
-    border: 'oklch(0.50 0.16 195 / 30%)',
+    bg: 'oklch(0.94 0.05 250)',
+    fg: 'oklch(0.45 0.18 250)',
+    border: 'oklch(0.65 0.16 250)',
   },
 } as const
 
@@ -91,7 +91,7 @@ export function AddEntrySheet({ open, onOpenChange, month }: AddEntrySheetProps)
 
   return (
     <Drawer open={open} onOpenChange={onOpenChange}>
-      <DrawerContent className="rounded-t-[20px] pb-safe">
+      <DrawerContent className="rounded-t-[22px] pb-safe">
         <DrawerHeader className="flex flex-row items-center justify-between px-4 py-2">
           <DrawerClose className="text-sm font-semibold text-sub-text">
             キャンセル
@@ -103,7 +103,7 @@ export function AddEntrySheet({ open, onOpenChange, month }: AddEntrySheetProps)
             type="submit"
             form="add-entry-form"
             disabled={submitting}
-            className="text-sm font-bold text-neon-cyan disabled:opacity-50"
+            className="text-sm font-bold text-accent disabled:opacity-50"
           >
             保存
           </button>
@@ -123,7 +123,7 @@ export function AddEntrySheet({ open, onOpenChange, month }: AddEntrySheetProps)
                   setIsCarryover(false)
                   setIsCleared(false)
                 }}
-                className="flex-1 py-2.5 rounded-[10px] text-[13px] font-semibold text-center transition-colors"
+                className="flex-1 py-2.5 rounded-[12px] text-[13px] font-bold text-center transition-colors"
                 style={{
                   background: active ? cfg.bg : 'var(--muted)',
                   color: active ? cfg.fg : 'var(--sub-text)',
@@ -150,7 +150,7 @@ export function AddEntrySheet({ open, onOpenChange, month }: AddEntrySheetProps)
             <Input
               name="label"
               placeholder="例：食費、家賃、給与"
-              className="h-12 rounded-xl"
+              className="h-12 rounded-[14px]"
               required
             />
           </div>
@@ -164,7 +164,7 @@ export function AddEntrySheet({ open, onOpenChange, month }: AddEntrySheetProps)
               type="number"
               inputMode="numeric"
               placeholder="¥ 0"
-              className="h-14 rounded-xl text-[28px] font-bold text-right font-tabular tracking-[-0.02em]"
+              className="h-14 rounded-[14px] text-[28px] font-bold text-right font-tabular tracking-[-0.02em]"
               min={1}
               required
             />
@@ -205,7 +205,7 @@ export function AddEntrySheet({ open, onOpenChange, month }: AddEntrySheetProps)
             type="submit"
             form="add-entry-form"
             disabled={submitting}
-            className="w-full py-4 bg-foreground text-background rounded-xl text-[15px] font-bold text-center disabled:opacity-50 transition-opacity"
+            className="w-full py-4 gradient-fab text-white rounded-full text-[15px] font-bold text-center shadow-fab disabled:opacity-50 transition-opacity"
           >
             {submitting ? '追加中...' : `${typeConfig[entryType].label}を追加`}
           </button>

--- a/src/components/features/add-entry-sheet.tsx
+++ b/src/components/features/add-entry-sheet.tsx
@@ -27,21 +27,12 @@ interface AddEntrySheetProps {
 const typeConfig = {
   income: {
     label: '収入',
-    bg: 'var(--neon-green-light)',
-    fg: 'var(--neon-green)',
-    border: 'var(--neon-green)',
   },
   expense: {
     label: '支出',
-    bg: 'var(--neon-red-light)',
-    fg: 'var(--neon-red)',
-    border: 'var(--neon-red)',
   },
   carryover: {
     label: '繰越',
-    bg: 'var(--neon-cyan-light)',
-    fg: 'var(--neon-cyan)',
-    border: 'var(--neon-cyan)',
   },
 } as const
 
@@ -110,7 +101,7 @@ export function AddEntrySheet({ open, onOpenChange, month }: AddEntrySheetProps)
         </DrawerHeader>
 
         {/* タイプタブ */}
-        <div className="flex gap-1 px-4 pb-3">
+        <div className="flex gap-1 mx-4 mb-3 bg-[#F3F4F6] rounded-[12px] h-9 p-[3px]">
           {(['income', 'expense', 'carryover'] as const).map((t) => {
             const active = entryType === t
             const cfg = typeConfig[t]
@@ -123,12 +114,11 @@ export function AddEntrySheet({ open, onOpenChange, month }: AddEntrySheetProps)
                   setIsCarryover(false)
                   setIsCleared(false)
                 }}
-                className="flex-1 py-2.5 rounded-[12px] text-[13px] font-bold text-center transition-colors"
-                style={{
-                  background: active ? cfg.bg : 'var(--muted)',
-                  color: active ? cfg.fg : 'var(--sub-text)',
-                  border: active ? `1px solid ${cfg.border}` : '1px solid transparent',
-                }}
+                className={`flex-1 rounded-lg text-[13px] text-center transition-colors ${
+                  active
+                    ? 'bg-[#2563EB] text-white font-semibold'
+                    : 'text-[#666666]'
+                }`}
               >
                 {cfg.label}
               </button>
@@ -150,7 +140,7 @@ export function AddEntrySheet({ open, onOpenChange, month }: AddEntrySheetProps)
             <Input
               name="label"
               placeholder="例：食費、家賃、給与"
-              className="h-12 rounded-[14px]"
+              className="h-11 rounded-lg bg-[#F3F4F6]"
               required
             />
           </div>
@@ -159,15 +149,18 @@ export function AddEntrySheet({ open, onOpenChange, month }: AddEntrySheetProps)
             <label className="text-[11px] font-bold tracking-[0.16em] uppercase text-sub-text mb-1.5 block">
               金額
             </label>
-            <Input
-              name="amount"
-              type="number"
-              inputMode="numeric"
-              placeholder="¥ 0"
-              className="h-14 rounded-[14px] text-[28px] font-bold text-right font-tabular tracking-[-0.02em]"
-              min={1}
-              required
-            />
+            <div className="relative">
+              <span className="absolute left-3 top-1/2 -translate-y-1/2 text-[#666666] text-sm">¥</span>
+              <Input
+                name="amount"
+                type="number"
+                inputMode="numeric"
+                placeholder="0"
+                className="h-11 rounded-lg border border-[#E5E7EB] pl-7 text-[28px] font-bold text-right font-tabular tracking-[-0.02em]"
+                min={1}
+                required
+              />
+            </div>
           </div>
 
           <div>
@@ -205,7 +198,7 @@ export function AddEntrySheet({ open, onOpenChange, month }: AddEntrySheetProps)
             type="submit"
             form="add-entry-form"
             disabled={submitting}
-            className="w-full py-4 gradient-fab text-white rounded-full text-[15px] font-bold text-center shadow-fab disabled:opacity-50 transition-opacity"
+            className="w-full h-12 bg-[#2563EB] text-white rounded-[12px] text-[15px] font-bold text-center shadow-[0_4px_12px_#2563EB33] disabled:opacity-50 transition-opacity"
           >
             {submitting ? '追加中...' : `${typeConfig[entryType].label}を追加`}
           </button>

--- a/src/components/features/copy-month-dialog.tsx
+++ b/src/components/features/copy-month-dialog.tsx
@@ -281,7 +281,7 @@ export function CopyMonthDialog({
       <DialogTrigger asChild>
         <Button variant="outline" size="sm" className="gap-1">
           <Copy className="h-4 w-4" />
-          前月からコピー
+          <span className="hidden sm:inline">前月からコピー</span>
         </Button>
       </DialogTrigger>
       <DialogContent className="max-h-[80vh] overflow-hidden flex flex-col">

--- a/src/components/features/export-csv-button.tsx
+++ b/src/components/features/export-csv-button.tsx
@@ -26,9 +26,9 @@ export function ExportCsvButton({
   }
 
   return (
-    <Button variant="outline" size="sm" onClick={handleExport}>
-      <Download className="mr-1 h-4 w-4" />
-      CSV出力
+    <Button variant="outline" size="sm" onClick={handleExport} className="gap-1">
+      <Download className="h-4 w-4" />
+      <span className="hidden sm:inline">CSV出力</span>
     </Button>
   )
 }

--- a/src/components/features/month-row.tsx
+++ b/src/components/features/month-row.tsx
@@ -21,7 +21,7 @@ export function MonthRow({
 
   if (!summary) {
     return (
-      <div className="flex items-center gap-2.5 py-3.5 border-b border-[#F3F4F6]">
+      <div className="flex items-center gap-2.5 py-3.5 border-b border-border">
         <span className="font-mono text-[11px] font-medium text-[#999999]">
           {monthNumber}
         </span>
@@ -43,7 +43,7 @@ export function MonthRow({
     <Link
       href={`/?month=${month}`}
       aria-label={`${formatMonth(month)}の詳細を開く`}
-      className="flex items-center gap-2.5 py-3.5 border-b border-[#F3F4F6] transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+      className="flex items-center gap-2.5 py-3.5 border-b border-border transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
     >
       {/* 月番号 */}
       <span className="font-mono text-[11px] font-medium text-[#999999]">

--- a/src/components/features/month-row.tsx
+++ b/src/components/features/month-row.tsx
@@ -77,8 +77,8 @@ export function MonthRow({
       <div
         className={`w-10 h-10 rounded-[12px] flex items-center justify-center text-[13px] font-bold font-tabular ${
           tone === 'pos'
-            ? 'bg-[oklch(0.94_0.08_155)] text-[oklch(0.42_0.16_155)]'
-            : 'bg-[oklch(0.94_0.07_25)] text-[oklch(0.50_0.18_25)]'
+            ? 'bg-neon-green-light text-neon-green'
+            : 'bg-neon-red-light text-neon-red'
         }`}
       >
         {String(index).padStart(2, '0')}

--- a/src/components/features/month-row.tsx
+++ b/src/components/features/month-row.tsx
@@ -47,40 +47,50 @@ export function MonthRow({
 }: MonthRowProps) {
   if (!summary) {
     return (
-      <div className="grid grid-cols-[64px_1fr_auto] items-center gap-3.5 px-5 py-4 border-b border-border/60 opacity-40">
-        <span className="text-[11px] font-bold tracking-[0.14em] uppercase text-sub-text font-tabular">
+      <div className="rounded-[16px] shadow-soft p-3 grid grid-cols-[40px_1fr_auto] items-center gap-3 opacity-55">
+        <div className="w-10 h-10 rounded-[12px] bg-muted flex items-center justify-center text-[13px] font-bold font-tabular text-sub-text">
           {String(index).padStart(2, '0')}
-        </span>
-        <div>
-          <span className="text-[18px] font-bold tracking-[-0.02em] font-tabular">
-            {index}月
-          </span>
-          <div className="text-[11px] text-sub-text tracking-[0.06em] mt-0.5">未記録</div>
         </div>
-        <span className="text-[18px] font-bold text-muted-foreground text-right font-tabular">
-          —
-        </span>
+        <div>
+          <span className="text-sm font-semibold">{index}月</span>
+          <div className="text-[11px] text-sub-text mt-0.5">未記録</div>
+        </div>
+        <span className="text-sm text-muted-foreground font-tabular">—</span>
       </div>
     )
   }
 
   const isPositive = summary.balance >= 0
   const sign = isPositive ? '+' : '−'
+  const tone = isPositive ? 'pos' : 'neg'
 
   return (
     <Link
       href={`/?month=${month}`}
       aria-label={`${formatMonth(month)}の詳細を開く`}
-      className={`grid grid-cols-[64px_1fr_auto] items-center gap-3.5 px-5 py-4 border-b border-border/60 transition-colors hover:bg-muted/30 outline-none focus-visible:ring-2 focus-visible:ring-ring/50 ${
-        isCurrentMonth ? 'bg-muted/30' : ''
+      className={`rounded-[16px] p-3 grid grid-cols-[40px_1fr_auto] items-center gap-3 transition-all outline-none focus-visible:ring-2 focus-visible:ring-ring/50 ${
+        isCurrentMonth
+          ? 'shadow-card-hover ring-1.5 ring-accent'
+          : 'shadow-soft hover:shadow-card-hover'
       }`}
     >
-      <span className="text-[11px] font-bold tracking-[0.14em] uppercase text-sub-text font-tabular">
+      <div
+        className={`w-10 h-10 rounded-[12px] flex items-center justify-center text-[13px] font-bold font-tabular ${
+          tone === 'pos'
+            ? 'bg-[oklch(0.94_0.08_155)] text-[oklch(0.42_0.16_155)]'
+            : 'bg-[oklch(0.94_0.07_25)] text-[oklch(0.50_0.18_25)]'
+        }`}
+      >
         {String(index).padStart(2, '0')}
-      </span>
+      </div>
       <div>
-        <span className="text-[18px] font-bold tracking-[-0.02em] font-tabular">
+        <span className="text-sm font-semibold">
           {index}月
+          {isCurrentMonth && (
+            <span className="ml-1.5 text-[9px] px-2 py-0.5 rounded-full bg-accent text-white font-bold tracking-[0.04em]">
+              NOW
+            </span>
+          )}
         </span>
         <div className="text-[11px] text-sub-text mt-0.5">
           収入 {formatCurrency(summary.incomeTotal)} · 支出 {formatCurrency(Math.abs(summary.expenseTotal))}
@@ -89,15 +99,13 @@ export function MonthRow({
       </div>
       <div className="text-right">
         <div
-          className={`text-[18px] font-bold tracking-[-0.02em] font-tabular ${
+          className={`text-sm font-bold font-tabular ${
             isPositive ? 'text-neon-green' : 'text-neon-red'
           }`}
         >
           {sign}{formatCurrency(Math.abs(summary.balance)).replace('¥', '¥')}
         </div>
-        <div className="text-[10px] text-sub-text mt-1 font-tabular tracking-[0.04em]">
-          {isCurrentMonth ? 'CURRENT ›' : 'View ›'}
-        </div>
+        <div className="text-[10px] text-sub-text mt-1">View ›</div>
       </div>
     </Link>
   )

--- a/src/components/features/month-row.tsx
+++ b/src/components/features/month-row.tsx
@@ -7,34 +7,7 @@ interface MonthRowProps {
   index: number
   summary: MonthlySummary | null
   isCurrentMonth: boolean
-  maxIncome: number
-  maxExpense: number
-}
-
-function SparkBars({
-  summary,
-  maxIncome,
-  maxExpense,
-}: {
-  summary: MonthlySummary
-  maxIncome: number
-  maxExpense: number
-}) {
-  const incomeH = Math.round((summary.incomeTotal / maxIncome) * 100)
-  const expenseH = Math.round((Math.abs(summary.expenseTotal) / maxExpense) * 100)
-
-  return (
-    <div className="flex items-end gap-0.5 h-[22px] mt-1.5">
-      <div
-        className="w-1 rounded-sm bg-neon-green"
-        style={{ height: `${Math.max(incomeH, 8)}%` }}
-      />
-      <div
-        className="w-1 rounded-sm bg-neon-red"
-        style={{ height: `${Math.max(expenseH, 8)}%` }}
-      />
-    </div>
-  )
+  maxBalance: number
 }
 
 export function MonthRow({
@@ -42,70 +15,75 @@ export function MonthRow({
   index,
   summary,
   isCurrentMonth,
-  maxIncome,
-  maxExpense,
+  maxBalance,
 }: MonthRowProps) {
+  const monthNumber = String(index).padStart(2, '0')
+
   if (!summary) {
     return (
-      <div className="rounded-[16px] shadow-soft p-3 grid grid-cols-[40px_1fr_auto] items-center gap-3 opacity-55">
-        <div className="w-10 h-10 rounded-[12px] bg-muted flex items-center justify-center text-[13px] font-bold font-tabular text-sub-text">
-          {String(index).padStart(2, '0')}
+      <div className="flex items-center gap-2.5 py-3.5 border-b border-[#F3F4F6]">
+        <span className="font-mono text-[11px] font-medium text-[#999999]">
+          {monthNumber}
+        </span>
+        <div className="flex-1">
+          <span className="text-base font-semibold text-[#999999]">{index}月</span>
         </div>
-        <div>
-          <span className="text-sm font-semibold">{index}月</span>
-          <div className="text-[11px] text-sub-text mt-0.5">未記録</div>
-        </div>
-        <span className="text-sm text-muted-foreground font-tabular">—</span>
+        <span className="text-[11px] text-[#999999]">未記録</span>
       </div>
     )
   }
 
   const isPositive = summary.balance >= 0
-  const sign = isPositive ? '+' : '−'
-  const tone = isPositive ? 'pos' : 'neg'
+  const barWidth = Math.min(
+    (Math.abs(summary.balance) / maxBalance) * 80,
+    80
+  )
 
   return (
     <Link
       href={`/?month=${month}`}
       aria-label={`${formatMonth(month)}の詳細を開く`}
-      className={`rounded-[16px] p-3 grid grid-cols-[40px_1fr_auto] items-center gap-3 transition-all outline-none focus-visible:ring-2 focus-visible:ring-ring/50 ${
-        isCurrentMonth
-          ? 'shadow-card-hover ring-1.5 ring-accent'
-          : 'shadow-soft hover:shadow-card-hover'
-      }`}
+      className="flex items-center gap-2.5 py-3.5 border-b border-[#F3F4F6] transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
     >
-      <div
-        className={`w-10 h-10 rounded-[12px] flex items-center justify-center text-[13px] font-bold font-tabular ${
-          tone === 'pos'
-            ? 'bg-neon-green-light text-neon-green'
-            : 'bg-neon-red-light text-neon-red'
-        }`}
-      >
-        {String(index).padStart(2, '0')}
-      </div>
-      <div>
-        <span className="text-sm font-semibold">
-          {index}月
+      {/* 月番号 */}
+      <span className="font-mono text-[11px] font-medium text-[#999999]">
+        {monthNumber}
+      </span>
+
+      {/* 中央部 */}
+      <div className="flex-1 flex flex-col gap-0.5">
+        <div className="flex items-center gap-1.5">
+          <span className="text-base font-semibold">{index}月</span>
           {isCurrentMonth && (
-            <span className="ml-1.5 text-[9px] px-2 py-0.5 rounded-full bg-accent text-white font-bold tracking-[0.04em]">
-              NOW
+            <span className="bg-[#EFF6FF] text-[#2563EB] text-[8px] font-bold px-2 py-0.5 rounded-full uppercase tracking-wide">
+              Now
             </span>
           )}
-        </span>
-        <div className="text-[11px] text-sub-text mt-0.5">
+        </div>
+        <div className="text-[10px] text-[#999999]">
           収入 {formatCurrency(summary.incomeTotal)} · 支出 {formatCurrency(Math.abs(summary.expenseTotal))}
         </div>
-        <SparkBars summary={summary} maxIncome={maxIncome} maxExpense={maxExpense} />
-      </div>
-      <div className="text-right">
+        {/* バランスバー */}
         <div
-          className={`text-sm font-bold font-tabular ${
-            isPositive ? 'text-neon-green' : 'text-neon-red'
+          className={`h-[3px] rounded-sm mt-0.5 ${
+            isPositive ? 'bg-[#2563EB]' : 'bg-[#E2483D]'
+          }`}
+          style={{ width: `${Math.max(barWidth, 4)}px` }}
+        />
+      </div>
+
+      {/* 右側 */}
+      <div className="flex flex-col items-end gap-0.5">
+        <span
+          className={`font-mono text-[13px] font-semibold ${
+            isPositive ? 'text-[#2563EB]' : 'text-[#E2483D]'
           }`}
         >
-          {sign}{formatCurrency(Math.abs(summary.balance)).replace('¥', '¥')}
-        </div>
-        <div className="text-[10px] text-sub-text mt-1">View ›</div>
+          {isPositive ? '+' : '-'}{formatCurrency(Math.abs(summary.balance)).replace('¥', '¥')}
+        </span>
+        <span className="text-[10px] font-medium text-[#2563EB]">
+          View &gt;
+        </span>
       </div>
     </Link>
   )

--- a/src/components/features/theme-toggle.tsx
+++ b/src/components/features/theme-toggle.tsx
@@ -10,13 +10,17 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 
-export function ThemeToggle() {
+interface ThemeToggleProps {
+  className?: string
+}
+
+export function ThemeToggle({ className }: ThemeToggleProps) {
   const { setTheme } = useTheme()
 
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="icon-sm" className="text-muted-foreground hover:text-accent">
+        <Button variant="ghost" size="icon-sm" className={className ?? 'text-muted-foreground hover:text-accent'}>
           <Sun className="h-4 w-4 rotate-0 scale-100 transition-[transform,opacity] dark:rotate-90 dark:scale-0" />
           <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-[transform,opacity] dark:rotate-0 dark:scale-100" />
           <span className="sr-only">テーマを切り替え</span>

--- a/src/components/layout/header-actions.tsx
+++ b/src/components/layout/header-actions.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { LogOut } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { ThemeToggle } from '@/components/features/theme-toggle'
+import { logout } from '@/app/actions/auth'
+
+interface HeaderActionsProps {
+  variant?: 'default' | 'hero'
+}
+
+export function HeaderActions({ variant = 'default' }: HeaderActionsProps) {
+  const iconClass = variant === 'hero'
+    ? 'text-white/70 hover:text-white'
+    : 'text-muted-foreground hover:text-accent'
+
+  return (
+    <div className="flex items-center gap-1">
+      <ThemeToggle className={iconClass} />
+      <form action={logout}>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          className={iconClass}
+          aria-label="ログアウト"
+        >
+          <LogOut className="h-4 w-4" />
+        </Button>
+      </form>
+    </div>
+  )
+}

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,104 +1,17 @@
 'use client'
 
-import { useState } from 'react'
-import { useRouter } from 'next/navigation'
-import { LogOut, ChevronLeft, ChevronRight } from 'lucide-react'
-import { AnimatePresence, motion } from 'motion/react'
+import { LogOut } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { ThemeToggle } from '@/components/features/theme-toggle'
-import { labelSlide, motionDuration, motionEase } from '@/components/animations/tokens'
-import { formatMonth, parseMonth } from '@/lib/utils/format'
 import { logout } from '@/app/actions/auth'
 
-interface HeaderProps {
-  currentMonth?: string
-}
-
-function useMonthDirection(currentMonth: string | undefined) {
-  const [state, setState] = useState({ prev: currentMonth ?? '', direction: 0 })
-  if (currentMonth && state.prev !== currentMonth) {
-    setState({
-      prev: currentMonth,
-      direction: currentMonth > state.prev ? 1 : -1,
-    })
-  }
-  return state.direction
-}
-
-const monthLabelVariants = {
-  enter: (d: number) => ({ x: d * labelSlide, opacity: 0 }),
-  center: { x: 0, opacity: 1 },
-  exit: (d: number) => ({ x: d * -labelSlide, opacity: 0 }),
-}
-
-export function Header({ currentMonth }: HeaderProps) {
-  const router = useRouter()
-  const direction = useMonthDirection(currentMonth)
-
-  function navigateMonth(offset: number) {
-    if (!currentMonth) return
-    const year = parseInt(currentMonth.slice(0, 4), 10)
-    const month = parseInt(currentMonth.slice(4, 6), 10)
-    const date = new Date(year, month - 1 + offset, 1)
-    router.push(`/?month=${parseMonth(date)}`)
-  }
-
-  function goToCurrentMonth() {
-    router.push(`/?month=${parseMonth(new Date())}`)
-  }
-
+export function Header() {
   return (
-    <header className="sticky top-0 z-50 bg-background border-b border-border">
-      <div className="container mx-auto px-4 py-3.5 flex items-center justify-between max-w-4xl">
-        <span className="text-[12px] font-bold tracking-[0.16em] uppercase text-sub-text">
-          Splitter
+    <header className="bg-background">
+      <div className="px-5 py-4 flex items-center justify-between max-w-4xl mx-auto">
+        <span className="text-[12px] font-bold tracking-[1px] uppercase text-foreground">
+          Score Splitter
         </span>
-
-        {currentMonth && (
-          <nav className="flex items-center gap-2" aria-label="月ナビゲーション">
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              aria-label="前月に移動"
-              onClick={() => navigateMonth(-1)}
-              className="h-7 w-7 rounded-full bg-muted text-accent"
-            >
-              <ChevronLeft className="h-3.5 w-3.5" />
-            </Button>
-            <button
-              type="button"
-              onClick={goToCurrentMonth}
-              aria-label="今月に移動"
-              aria-live="polite"
-              className="text-sm font-semibold min-w-[100px] text-center hover:text-accent transition-colors duration-200 outline-none focus-visible:ring-2 focus-visible:ring-ring/50 rounded-md overflow-hidden font-tabular"
-            >
-              <AnimatePresence mode="wait" initial={false} custom={direction}>
-                <motion.span
-                  key={currentMonth}
-                  custom={direction}
-                  variants={monthLabelVariants}
-                  initial="enter"
-                  animate="center"
-                  exit="exit"
-                  transition={{ duration: motionDuration.fast, ease: motionEase.out }}
-                  className="inline-block"
-                >
-                  {formatMonth(currentMonth)}
-                </motion.span>
-              </AnimatePresence>
-            </button>
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              aria-label="翌月に移動"
-              onClick={() => navigateMonth(1)}
-              className="h-7 w-7 rounded-full bg-muted text-accent"
-            >
-              <ChevronRight className="h-3.5 w-3.5" />
-            </Button>
-          </nav>
-        )}
-
         <div className="flex items-center gap-1">
           <ThemeToggle />
           <form action={logout}>

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,9 +1,6 @@
 'use client'
 
-import { LogOut } from 'lucide-react'
-import { Button } from '@/components/ui/button'
-import { ThemeToggle } from '@/components/features/theme-toggle'
-import { logout } from '@/app/actions/auth'
+import { HeaderActions } from '@/components/layout/header-actions'
 
 export function Header() {
   return (
@@ -12,14 +9,7 @@ export function Header() {
         <span className="text-[12px] font-bold tracking-[1px] uppercase text-foreground">
           Score Splitter
         </span>
-        <div className="flex items-center gap-1">
-          <ThemeToggle />
-          <form action={logout}>
-            <Button variant="ghost" size="icon-sm" className="text-muted-foreground hover:text-accent" aria-label="ログアウト">
-              <LogOut className="h-4 w-4" />
-            </Button>
-          </form>
-        </div>
+        <HeaderActions />
       </div>
     </header>
   )

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -48,20 +48,20 @@ export function Header({ currentMonth }: HeaderProps) {
   }
 
   return (
-    <header className="sticky top-0 z-50 glass-strong border-b border-border/50">
-      <div className="container mx-auto px-4 py-3 flex items-center justify-between max-w-4xl">
-        <span className="text-[13px] font-bold tracking-[0.18em] uppercase text-foreground">
-          Score Splitter
+    <header className="sticky top-0 z-50 bg-background border-b border-border">
+      <div className="container mx-auto px-4 py-3.5 flex items-center justify-between max-w-4xl">
+        <span className="text-[12px] font-bold tracking-[0.16em] uppercase text-sub-text">
+          Splitter
         </span>
 
         {currentMonth && (
           <nav className="flex items-center gap-2" aria-label="月ナビゲーション">
             <Button
-              variant="outline"
+              variant="ghost"
               size="icon-sm"
               aria-label="前月に移動"
               onClick={() => navigateMonth(-1)}
-              className="h-7 w-7 rounded-lg border-border"
+              className="h-7 w-7 rounded-full bg-muted text-accent"
             >
               <ChevronLeft className="h-3.5 w-3.5" />
             </Button>
@@ -88,11 +88,11 @@ export function Header({ currentMonth }: HeaderProps) {
               </AnimatePresence>
             </button>
             <Button
-              variant="outline"
+              variant="ghost"
               size="icon-sm"
               aria-label="翌月に移動"
               onClick={() => navigateMonth(1)}
-              className="h-7 w-7 rounded-lg border-border"
+              className="h-7 w-7 rounded-full bg-muted text-accent"
             >
               <ChevronRight className="h-3.5 w-3.5" />
             </Button>

--- a/src/components/layout/month-toolbar.tsx
+++ b/src/components/layout/month-toolbar.tsx
@@ -2,7 +2,6 @@
 
 import Link from 'next/link'
 import { ArrowLeft } from 'lucide-react'
-import { Button } from '@/components/ui/button'
 import { CopyMonthDialog } from '@/components/features/copy-month-dialog'
 import { ExportCsvButton } from '@/components/features/export-csv-button'
 import { getPreviousMonth } from '@/lib/utils/format'
@@ -19,14 +18,16 @@ export function MonthToolbar({ currentMonth, incomes, expenses, carryovers }: Mo
   const previousMonth = getPreviousMonth(currentMonth)
 
   return (
-    <div className="flex items-center justify-between">
-      <Button variant="ghost" size="sm" asChild className="text-sub-text hover:text-foreground -ml-2">
-        <Link href="/" aria-label="月の一覧へ戻る">
-          <ArrowLeft className="h-3.5 w-3.5" />
-          <span className="text-xs">一覧へ</span>
-        </Link>
-      </Button>
-      <div className="flex gap-1">
+    <div className="flex items-center justify-between py-1">
+      <Link
+        href="/"
+        aria-label="月の一覧へ戻る"
+        className="inline-flex items-center gap-1 text-sub-text text-xs hover:text-foreground transition-colors"
+      >
+        <ArrowLeft className="h-3 w-3" />
+        <span>一覧へ</span>
+      </Link>
+      <div className="flex gap-1.5">
         <CopyMonthDialog
           currentMonth={currentMonth}
           previousMonth={previousMonth}

--- a/src/components/sections/calculation-section.tsx
+++ b/src/components/sections/calculation-section.tsx
@@ -2,7 +2,6 @@
 
 import { MiniBarChart } from '@/components/charts/mini-bar-chart'
 import { AnimatedYen } from '@/components/animations/animated-number'
-import { PersonBadge } from '@/components/ui/person-badge'
 import { calculateSettlement, filterCarryoverExpenses, filterClearedCarryovers } from '@/lib/utils/calculation'
 import { calculateMonthBalance } from '@/lib/utils/monthly-summary'
 import { formatCurrency } from '@/lib/utils/format'
@@ -52,91 +51,85 @@ export function CalculationSection({
 
 
   return (
-    <div data-section="calculation">
+    <div data-section="calculation" className="space-y-4">
       {/* ヒーロー: 月表示 + 収支 + チャート */}
-      <section className="py-8 md:py-10 md:px-6 border-b border-border">
-        <div className="flex items-baseline justify-between gap-4">
-          <div>
-            <div className="text-[11px] font-bold tracking-[0.22em] uppercase text-sub-text">
-              Balance / 月の収支
-            </div>
-            <div className="text-[36px] md:text-[56px] font-bold tracking-[-0.04em] leading-[0.95] font-tabular mt-2">
-              {formatMonthDot(currentMonth)}
-            </div>
-            <div className="text-xs md:text-sm text-sub-text mt-1.5">
-              {m}月度 — {days}日間 / {totalItems}件の取引
-            </div>
+      <section className="rounded-[22px] gradient-hero-card shadow-soft-lg p-5 md:p-6">
+        <div className="text-[11px] font-bold tracking-[0.16em] uppercase text-accent">
+          Balance / 月の収支
+        </div>
+        <div className="text-[30px] md:text-[44px] font-bold tracking-[-0.03em] leading-[0.95] font-tabular mt-2">
+          {formatMonthDot(currentMonth)}
+        </div>
+        <div className="text-xs text-sub-text mt-1.5">
+          {m}月度 — {days}日間 / {totalItems}件の取引
+        </div>
+
+        <div className="mt-5 md:mt-6">
+          <div className="text-[11px] font-bold tracking-[0.14em] uppercase text-sub-text">
+            月の収支
+          </div>
+          <div className="mt-1.5 flex items-baseline">
+            <AnimatedYen
+              value={monthlyBalance}
+              className={`text-[44px] md:text-[64px] font-bold tracking-[-0.04em] leading-[0.9] font-tabular ${
+                monthlyBalance >= 0
+                  ? 'text-neon-green'
+                  : 'text-neon-red'
+              }`}
+            />
+          </div>
+          <div className="text-xs text-sub-text mt-2.5 leading-relaxed">
+            収入 {formatCurrency(result.totalIncome)} − 支出 {formatCurrency(Math.abs(allExpenseTotal))}
           </div>
         </div>
 
-        <div className="mt-6 md:mt-8 grid gap-8 md:gap-14 md:grid-cols-[1.5fr_1fr] items-end">
-          <div>
-            <div className="text-[12px] font-semibold tracking-[0.18em] uppercase text-sub-text">
-              月の収支
-            </div>
-            <div className="mt-2 flex items-baseline">
-              <AnimatedYen
-                value={monthlyBalance}
-                className={`text-[48px] md:text-[88px] font-bold tracking-[-0.04em] leading-[0.9] font-tabular ${
-                  monthlyBalance >= 0
-                    ? 'text-neon-green'
-                    : 'text-neon-red'
-                }`}
-              />
-            </div>
-            <div className="text-xs md:text-sm text-sub-text mt-3 leading-relaxed">
-              収入 {formatCurrency(result.totalIncome)} − 支出 {formatCurrency(Math.abs(allExpenseTotal))}
-            </div>
-          </div>
-
-          {recentSummaries.length > 0 && (
+        {recentSummaries.length > 0 && (
+          <div className="mt-5">
             <MiniBarChart summaries={recentSummaries} currentMonth={currentMonth} />
-          )}
-        </div>
+          </div>
+        )}
       </section>
 
       {/* 第2階層: お小遣い + 精算 */}
-      <section className="grid md:grid-cols-[1.4fr_1fr] border-b border-border">
-        <div className="py-5 md:py-7 md:px-6 flex flex-col gap-1.5 border-b md:border-b-0 border-border">
-          <div className="text-[10px] md:text-[11px] font-bold tracking-[0.22em] uppercase text-sub-text">
+      <section className="flex flex-col gap-3">
+        <div className="rounded-[18px] bg-card shadow-soft p-4">
+          <div className="text-[11px] font-bold tracking-[0.16em] uppercase text-sub-text">
             Allowance / お小遣い（1人あたり）
           </div>
           <AnimatedYen
             value={result.allowance}
-            className="text-[28px] md:text-[44px] font-bold tracking-[-0.03em] leading-[0.95] font-tabular"
+            className="text-[26px] md:text-[36px] font-bold tracking-[-0.03em] leading-[0.95] font-tabular mt-2"
           />
-          <div className="text-[11px] md:text-[13px] text-sub-text mt-1">
+          <div className="text-[11px] text-sub-text mt-2 leading-relaxed">
             {hasAdjustments
               ? `収支 ${formatCurrency(monthlyBalance)} ＋ 調整 ${formatCurrency(carryoverExpenseTotal + clearedCarryoverTotal)} の余剰を等分`
               : '余剰を2人で等分'}
           </div>
         </div>
 
-        <div className="py-5 md:py-7 md:px-6 flex flex-col gap-1.5 md:border-l border-border md:bg-muted/30">
-          <div className="text-[10px] md:text-[11px] font-bold tracking-[0.22em] uppercase text-sub-text">
+        <div className="rounded-[18px] bg-card shadow-soft p-4">
+          <div className="text-[11px] font-bold tracking-[0.16em] uppercase text-sub-text">
             Settlement / 精算額
           </div>
           {result.settlement !== 0 ? (
-            <>
+            <div className="flex items-center justify-between mt-2">
               <AnimatedYen
                 value={result.settlement}
                 absolute
-                className="text-[22px] md:text-[28px] font-bold tracking-[-0.02em] leading-[0.95] font-tabular text-neon-cyan"
+                className="text-[22px] md:text-[28px] font-bold tracking-[-0.02em] leading-[0.95] font-tabular text-accent"
               />
-              <div className="flex items-center gap-2.5 mt-2">
-                <span className="inline-flex items-center gap-1.5 text-[11px] md:text-[13px] font-semibold text-husband">
-                  <span className="w-2 h-2 rounded-full bg-husband" />
+              <div className="flex items-center gap-1.5">
+                <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-husband-light text-[11px] font-bold text-husband">
                   夫
                 </span>
-                <span className="text-sub-text text-sm">──→</span>
-                <span className="inline-flex items-center gap-1.5 text-[11px] md:text-[13px] font-semibold text-wife">
-                  <span className="w-2 h-2 rounded-full bg-wife" />
+                <span className="text-sub-text text-xs">→</span>
+                <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-wife-light text-[11px] font-bold text-wife">
                   妻
                 </span>
               </div>
-            </>
+            </div>
           ) : (
-            <span className="text-[22px] md:text-[28px] font-bold text-muted-foreground">
+            <span className="text-[22px] md:text-[28px] font-bold text-muted-foreground mt-2 block">
               精算なし
             </span>
           )}

--- a/src/components/sections/carryover-section.tsx
+++ b/src/components/sections/carryover-section.tsx
@@ -20,22 +20,22 @@ export function CarryoverSection({ carryovers, month }: CarryoverSectionProps) {
   const total = carryovers.reduce((sum, c) => sum + Math.abs(c.amount), 0)
 
   return (
-    <section data-section="carryover" className="py-6 md:py-8 md:px-6 border-t border-border">
-      <div className="flex items-baseline justify-between border-b border-foreground pb-2.5 mb-1">
+    <section data-section="carryover">
+      <div className="flex items-baseline justify-between pb-2 mb-1">
         <h3
           data-testid="carryover-title"
-          className="text-[11px] md:text-sm font-bold tracking-[0.16em] uppercase"
+          className="text-[12px] font-bold tracking-[0.10em] uppercase"
         >
           Carryover / 繰越
         </h3>
-        <span className="text-[10px] md:text-xs text-sub-text font-tabular">
+        <span className="text-[10px] text-sub-text font-tabular">
           合計 {formatCurrency(total)}{clearedCarryovers.length > 0 && ` / 清算済み ${clearedCarryovers.length}件`}
         </span>
       </div>
 
-      <div>
+      <div className="rounded-[18px] bg-card shadow-soft overflow-hidden">
         <AnimatePresence initial={false}>
-          {carryovers.map((carryover) => (
+          {carryovers.map((carryover, i) => (
             <motion.div
               key={carryover.id}
               data-testid="item-row"
@@ -44,25 +44,30 @@ export function CarryoverSection({ carryovers, month }: CarryoverSectionProps) {
               animate={{ opacity: carryover.isCleared ? 0.6 : 1, y: 0 }}
               exit={{ opacity: 0, x: -8, transition: listExit }}
               transition={listSpring}
-              className="group flex items-center justify-between gap-3 py-3 border-b border-border"
+              className={`group grid grid-cols-[32px_1fr_auto] gap-3 px-3.5 py-3 items-center ${
+                i < carryovers.length - 1 ? 'border-b border-border' : ''
+              }`}
             >
-              <div className="flex items-center gap-3 min-w-0">
-                <span className="text-[10px] font-bold shrink-0"
-                  style={{ color: `var(--${carryover.person})` }}
-                >
-                  {carryover.person === 'husband' ? '夫' : '妻'}
-                </span>
-                <span className={`text-sm md:text-base font-medium truncate ${carryover.isCleared ? 'line-through opacity-60' : ''}`}>
-                  {carryover.label}
-                </span>
+              <span
+                className="w-7 h-7 rounded-full text-white text-[11px] font-bold inline-flex items-center justify-center shrink-0"
+                style={{
+                  background: carryover.person === 'husband'
+                    ? 'linear-gradient(135deg, oklch(0.65 0.16 250), oklch(0.55 0.18 260))'
+                    : 'linear-gradient(135deg, oklch(0.75 0.16 350), oklch(0.65 0.18 20))',
+                }}
+              >
+                {carryover.person === 'husband' ? '夫' : '妻'}
+              </span>
+              <span className={`text-sm font-medium truncate ${carryover.isCleared ? 'line-through opacity-60' : ''}`}>
+                {carryover.label}
                 {carryover.isCleared && (
-                  <span className="text-[10px] px-2 py-0.5 rounded-full bg-neon-green/10 text-neon-green font-bold tracking-[0.06em] shrink-0">
+                  <span className="ml-1.5 text-[10px] px-1.5 py-0.5 rounded-full bg-neon-green/10 text-neon-green font-bold no-underline inline-block">
                     清算済
                   </span>
                 )}
-              </div>
-              <div className="flex items-center gap-2">
-                <span className={`text-sm md:text-base font-semibold font-tabular ${
+              </span>
+              <div className="flex items-center gap-1">
+                <span className={`text-sm font-semibold font-tabular ${
                   carryover.isCleared ? 'text-neon-green line-through' : 'text-sub-text'
                 }`}>
                   {formatCurrency(Math.abs(carryover.amount))}
@@ -73,7 +78,7 @@ export function CarryoverSection({ carryovers, month }: CarryoverSectionProps) {
                   }}>
                     <button
                       type="submit"
-                      className={`h-7 w-7 flex items-center justify-center rounded-lg text-xs transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring/50 ${
+                      className={`h-7 w-7 flex items-center justify-center rounded-full text-xs transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring/50 ${
                         carryover.isCleared
                           ? 'text-neon-green bg-neon-green/10'
                           : 'text-muted-foreground hover:text-neon-green hover:bg-neon-green/10'
@@ -112,10 +117,10 @@ export function CarryoverSection({ carryovers, month }: CarryoverSectionProps) {
             <p className="text-xs">繰越がありません</p>
           </div>
         )}
-      </div>
 
-      <div className="pb-4">
-        <AddEntryModal type="carryover" month={month} />
+        <div className="border-t border-border bg-[var(--surface-total)] px-3.5 py-2.5">
+          <AddEntryModal type="carryover" month={month} />
+        </div>
       </div>
     </section>
   )

--- a/src/components/sections/carryover-section.tsx
+++ b/src/components/sections/carryover-section.tsx
@@ -52,8 +52,8 @@ export function CarryoverSection({ carryovers, month }: CarryoverSectionProps) {
                 className="w-7 h-7 rounded-full text-white text-[11px] font-bold inline-flex items-center justify-center shrink-0"
                 style={{
                   background: carryover.person === 'husband'
-                    ? 'linear-gradient(135deg, oklch(0.65 0.16 250), oklch(0.55 0.18 260))'
-                    : 'linear-gradient(135deg, oklch(0.75 0.16 350), oklch(0.65 0.18 20))',
+                    ? 'var(--gradient-husband)'
+                    : 'var(--gradient-wife)',
                 }}
               >
                 {carryover.person === 'husband' ? '夫' : '妻'}

--- a/src/components/sections/carryover-section.tsx
+++ b/src/components/sections/carryover-section.tsx
@@ -24,16 +24,17 @@ export function CarryoverSection({ carryovers, month }: CarryoverSectionProps) {
       <div className="flex items-baseline justify-between pb-2 mb-1">
         <h3
           data-testid="carryover-title"
-          className="text-[12px] font-bold tracking-[0.10em] uppercase"
+          className="text-[11px] font-bold tracking-[0.8px] text-foreground uppercase"
         >
           Carryover / 繰越
         </h3>
-        <span className="text-[10px] text-sub-text font-tabular">
+        <span className="text-[11px] text-[#999999]">
           合計 {formatCurrency(total)}{clearedCarryovers.length > 0 && ` / 清算済み ${clearedCarryovers.length}件`}
         </span>
       </div>
 
       <div className="rounded-[18px] bg-card shadow-soft overflow-hidden">
+        <div className="border-b border-[#E5E7EB]" />
         <AnimatePresence initial={false}>
           {carryovers.map((carryover, i) => (
             <motion.div
@@ -44,31 +45,28 @@ export function CarryoverSection({ carryovers, month }: CarryoverSectionProps) {
               animate={{ opacity: carryover.isCleared ? 0.6 : 1, y: 0 }}
               exit={{ opacity: 0, x: -8, transition: listExit }}
               transition={listSpring}
-              className={`group grid grid-cols-[32px_1fr_auto] gap-3 px-3.5 py-3 items-center ${
+              className={`group grid grid-cols-[22px_1fr_auto] gap-3 px-3.5 py-3 items-center ${
                 i < carryovers.length - 1 ? 'border-b border-border' : ''
               }`}
             >
               <span
-                className="w-7 h-7 rounded-full text-white text-[11px] font-bold inline-flex items-center justify-center shrink-0"
-                style={{
-                  background: carryover.person === 'husband'
-                    ? 'var(--gradient-husband)'
-                    : 'var(--gradient-wife)',
-                }}
+                className={`w-[22px] h-[22px] rounded-full text-white text-[8px] font-bold inline-flex items-center justify-center shrink-0 ${
+                  carryover.person === 'husband' ? 'bg-husband' : 'bg-wife'
+                }`}
               >
                 {carryover.person === 'husband' ? '夫' : '妻'}
               </span>
-              <span className={`text-sm font-medium truncate ${carryover.isCleared ? 'line-through opacity-60' : ''}`}>
+              <span className={`text-[13px] font-medium truncate ${carryover.isCleared ? 'line-through opacity-60' : ''}`}>
                 {carryover.label}
                 {carryover.isCleared && (
-                  <span className="ml-1.5 text-[10px] px-1.5 py-0.5 rounded-full bg-neon-green/10 text-neon-green font-bold no-underline inline-block">
+                  <span className="ml-1.5 text-[8px] px-1.5 py-0.5 rounded-full bg-[#EFF6FF] text-[#2563EB] font-bold no-underline inline-block">
                     清算済
                   </span>
                 )}
               </span>
               <div className="flex items-center gap-1">
-                <span className={`text-sm font-semibold font-tabular ${
-                  carryover.isCleared ? 'text-neon-green line-through' : 'text-sub-text'
+                <span className={`font-mono text-[13px] font-semibold ${
+                  carryover.isCleared ? 'text-foreground line-through' : 'text-foreground'
                 }`}>
                   {formatCurrency(Math.abs(carryover.amount))}
                 </span>

--- a/src/components/sections/expense-section.tsx
+++ b/src/components/sections/expense-section.tsx
@@ -21,41 +21,48 @@ export function ExpenseSection({ expenses, month }: ExpenseSectionProps) {
 
   return (
     <div data-section="expense">
-      <div className="flex items-baseline justify-between border-b border-foreground pb-2.5 mb-1">
-        <h3 className="text-[11px] md:text-sm font-bold tracking-[0.16em] uppercase">
+      <div className="flex items-baseline justify-between pb-2 mb-1">
+        <h3 className="text-[12px] font-bold tracking-[0.10em] uppercase">
           Expense / 支出
         </h3>
-        <span className="text-[10px] md:text-xs text-sub-text font-tabular">
+        <span className="text-[10px] text-sub-text font-tabular">
           {expenses.length}件{carryoverExpenses.length > 0 && ` — 繰越 ${carryoverExpenses.length}件`}
         </span>
       </div>
 
-      <div>
+      <div className="rounded-[18px] bg-card shadow-soft overflow-hidden">
         <AnimatePresence initial={false}>
-          {expenses.map((expense) => (
+          {expenses.map((expense, i) => (
             <motion.div
               key={expense.id}
               data-testid="item-row"
               layout
               initial={{ opacity: 0, y: -6 }}
-              animate={{ opacity: expense.isCarryover ? 0.5 : 1, y: 0 }}
+              animate={{ opacity: expense.isCarryover ? 0.55 : 1, y: 0 }}
               exit={{ opacity: 0, x: -8, transition: listExit }}
               transition={listSpring}
-              className="group grid grid-cols-[24px_1fr_auto] gap-3 py-3 border-b border-border items-baseline"
+              className={`group grid grid-cols-[32px_1fr_auto] gap-3 px-3.5 py-3 items-center ${
+                i < expenses.length - 1 ? 'border-b border-border' : ''
+              }`}
             >
-              <span className="text-[10px] font-bold"
-                style={{ color: `var(--${expense.person})` }}
+              <span
+                className="w-7 h-7 rounded-full text-white text-[11px] font-bold inline-flex items-center justify-center shrink-0"
+                style={{
+                  background: expense.person === 'husband'
+                    ? 'linear-gradient(135deg, oklch(0.65 0.16 250), oklch(0.55 0.18 260))'
+                    : 'linear-gradient(135deg, oklch(0.75 0.16 350), oklch(0.65 0.18 20))',
+                }}
               >
                 {expense.person === 'husband' ? '夫' : '妻'}
               </span>
-              <span className="text-sm md:text-base font-medium truncate">
+              <span className="text-sm font-medium truncate">
                 {expense.label}
                 {expense.isCarryover && (
-                  <span className="ml-2 text-[10px] text-sub-text">繰越</span>
+                  <span className="ml-1.5 text-[10px] px-1.5 py-0.5 rounded-full bg-muted text-sub-text font-bold">繰越</span>
                 )}
               </span>
               <div className="flex items-center gap-1">
-                <span className={`text-sm md:text-base font-semibold font-tabular ${
+                <span className={`text-sm font-semibold font-tabular ${
                   expense.isCarryover ? 'text-muted-foreground' : 'text-neon-red'
                 }`}>
                   {expense.isCarryover ? '' : '−'}{formatCurrency(expense.amount).replace('-', '').replace('¥', '¥')}
@@ -66,7 +73,7 @@ export function ExpenseSection({ expenses, month }: ExpenseSectionProps) {
                   }}>
                     <button
                       type="submit"
-                      className={`h-7 w-7 flex items-center justify-center rounded-lg text-xs transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring/50 ${
+                      className={`h-7 w-7 flex items-center justify-center rounded-full text-xs transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring/50 ${
                         expense.isCarryover
                           ? 'text-accent bg-accent/10'
                           : 'text-muted-foreground hover:text-accent hover:bg-accent/10'
@@ -105,19 +112,19 @@ export function ExpenseSection({ expenses, month }: ExpenseSectionProps) {
             <p className="text-xs">支出がありません</p>
           </div>
         )}
-      </div>
 
-      <div className="pb-4">
-        <AddEntryModal type="expense" month={month} />
-      </div>
+        <div className="border-t border-border bg-[var(--surface-total)] px-3.5 py-2.5">
+          <AddEntryModal type="expense" month={month} />
+        </div>
 
-      <div className="flex items-baseline justify-between pt-4 border-t-2 border-foreground">
-        <span className="text-[10px] md:text-[11px] font-bold tracking-[0.16em] uppercase text-sub-text">
-          Total
-        </span>
-        <span className="text-xl md:text-[28px] font-bold font-tabular tracking-[-0.02em] text-neon-red">
-          −{formatCurrency(actualTotal).replace('-', '')}
-        </span>
+        <div className="flex items-baseline justify-between px-3.5 py-3 border-t border-border bg-[var(--surface-total)]">
+          <span className="text-[10px] font-bold tracking-[0.14em] uppercase text-sub-text">
+            Total
+          </span>
+          <span className="text-lg font-bold font-tabular tracking-[-0.01em] text-neon-red">
+            −{formatCurrency(actualTotal).replace('-', '')}
+          </span>
+        </div>
       </div>
     </div>
   )

--- a/src/components/sections/expense-section.tsx
+++ b/src/components/sections/expense-section.tsx
@@ -49,8 +49,8 @@ export function ExpenseSection({ expenses, month }: ExpenseSectionProps) {
                 className="w-7 h-7 rounded-full text-white text-[11px] font-bold inline-flex items-center justify-center shrink-0"
                 style={{
                   background: expense.person === 'husband'
-                    ? 'linear-gradient(135deg, oklch(0.65 0.16 250), oklch(0.55 0.18 260))'
-                    : 'linear-gradient(135deg, oklch(0.75 0.16 350), oklch(0.65 0.18 20))',
+                    ? 'var(--gradient-husband)'
+                    : 'var(--gradient-wife)',
                 }}
               >
                 {expense.person === 'husband' ? '夫' : '妻'}

--- a/src/components/sections/expense-section.tsx
+++ b/src/components/sections/expense-section.tsx
@@ -22,15 +22,16 @@ export function ExpenseSection({ expenses, month }: ExpenseSectionProps) {
   return (
     <div data-section="expense">
       <div className="flex items-baseline justify-between pb-2 mb-1">
-        <h3 className="text-[12px] font-bold tracking-[0.10em] uppercase">
+        <h3 className="text-[11px] font-bold tracking-[0.8px] text-foreground uppercase">
           Expense / 支出
         </h3>
-        <span className="text-[10px] text-sub-text font-tabular">
+        <span className="text-[11px] text-[#999999]">
           {expenses.length}件{carryoverExpenses.length > 0 && ` — 繰越 ${carryoverExpenses.length}件`}
         </span>
       </div>
 
       <div className="rounded-[18px] bg-card shadow-soft overflow-hidden">
+        <div className="border-b border-[#E5E7EB]" />
         <AnimatePresence initial={false}>
           {expenses.map((expense, i) => (
             <motion.div
@@ -41,29 +42,26 @@ export function ExpenseSection({ expenses, month }: ExpenseSectionProps) {
               animate={{ opacity: expense.isCarryover ? 0.55 : 1, y: 0 }}
               exit={{ opacity: 0, x: -8, transition: listExit }}
               transition={listSpring}
-              className={`group grid grid-cols-[32px_1fr_auto] gap-3 px-3.5 py-3 items-center ${
+              className={`group grid grid-cols-[22px_1fr_auto] gap-3 px-3.5 py-3 items-center ${
                 i < expenses.length - 1 ? 'border-b border-border' : ''
               }`}
             >
               <span
-                className="w-7 h-7 rounded-full text-white text-[11px] font-bold inline-flex items-center justify-center shrink-0"
-                style={{
-                  background: expense.person === 'husband'
-                    ? 'var(--gradient-husband)'
-                    : 'var(--gradient-wife)',
-                }}
+                className={`w-[22px] h-[22px] rounded-full text-white text-[8px] font-bold inline-flex items-center justify-center shrink-0 ${
+                  expense.person === 'husband' ? 'bg-husband' : 'bg-wife'
+                } ${expense.isCarryover ? 'opacity-50' : ''}`}
               >
                 {expense.person === 'husband' ? '夫' : '妻'}
               </span>
-              <span className="text-sm font-medium truncate">
+              <span className={`text-[13px] font-medium truncate ${expense.isCarryover ? 'text-[#999999]' : ''}`}>
                 {expense.label}
                 {expense.isCarryover && (
-                  <span className="ml-1.5 text-[10px] px-1.5 py-0.5 rounded-full bg-muted text-sub-text font-bold">繰越</span>
+                  <span className="ml-1.5 text-[8px] px-1.5 py-0.5 rounded-full bg-[#EFF6FF] text-[#2563EB] font-bold">繰越</span>
                 )}
               </span>
               <div className="flex items-center gap-1">
-                <span className={`text-sm font-semibold font-tabular ${
-                  expense.isCarryover ? 'text-muted-foreground' : 'text-neon-red'
+                <span className={`font-mono text-[13px] font-semibold ${
+                  expense.isCarryover ? 'text-[#999999]' : 'text-[#E2483D]'
                 }`}>
                   {expense.isCarryover ? '' : '−'}{formatCurrency(expense.amount).replace('-', '').replace('¥', '¥')}
                 </span>
@@ -118,10 +116,10 @@ export function ExpenseSection({ expenses, month }: ExpenseSectionProps) {
         </div>
 
         <div className="flex items-baseline justify-between px-3.5 py-3 border-t border-border bg-[var(--surface-total)]">
-          <span className="text-[10px] font-bold tracking-[0.14em] uppercase text-sub-text">
+          <span className="text-[11px] text-[#999999] font-semibold tracking-[0.8px] uppercase">
             Total
           </span>
-          <span className="text-lg font-bold font-tabular tracking-[-0.01em] text-neon-red">
+          <span className="font-mono text-[15px] font-bold text-[#E2483D]">
             −{formatCurrency(actualTotal).replace('-', '')}
           </span>
         </div>

--- a/src/components/sections/hero-section.tsx
+++ b/src/components/sections/hero-section.tsx
@@ -88,7 +88,7 @@ export function HeroSection({
 
   return (
     <section
-      className="relative overflow-hidden rounded-t-[20px]"
+      className="relative overflow-hidden"
       style={{
         background: `
           linear-gradient(to bottom, transparent 55%, #FAFBFCAA 80%, #FAFBFC 100%),
@@ -109,7 +109,7 @@ export function HeroSection({
       <div className="absolute w-[120px] h-[120px] rounded-full bg-white opacity-[0.05] left-[-30px] top-[140px] pointer-events-none" />
       <div className="absolute w-[80px] h-[80px] rounded-full bg-[#A5B4FC] opacity-[0.08] right-[20px] bottom-[200px] pointer-events-none" />
 
-      <div className="relative flex flex-col gap-3 pt-4 px-5 pb-7">
+      <div className="relative flex flex-col gap-3 pt-[calc(env(safe-area-inset-top)+16px)] px-5 pb-7">
         {/* Top Bar */}
         <div className="flex items-center justify-between">
           <span className="text-[13px] font-bold tracking-[1.5px] text-white">

--- a/src/components/sections/hero-section.tsx
+++ b/src/components/sections/hero-section.tsx
@@ -126,11 +126,36 @@ export function HeroSection({
       <div className="absolute w-[80px] h-[80px] rounded-full bg-[#A5B4FC] opacity-[0.08] right-[20px] bottom-[200px] pointer-events-none" />
 
       <div className="relative flex flex-col gap-3 pt-[calc(env(safe-area-inset-top)+16px)] px-5 pb-7">
-        {/* Top Bar */}
+        {/* Header — 月一覧と同じ */}
         <div className="flex items-center justify-between">
-          <span className="text-[13px] font-bold tracking-[1.5px] text-white">
-            SPLITTER
+          <span className="text-[12px] font-bold tracking-[1px] text-white uppercase">
+            Score Splitter
           </span>
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              aria-label="テーマ切り替え"
+              onClick={() => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')}
+              className="text-white/70 hover:text-white transition-colors"
+            >
+              <Moon className="h-4 w-4" />
+            </button>
+            <button type="button" aria-label="設定" className="text-white/70 hover:text-white transition-colors">
+              <Settings className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+
+        {/* Nav — 一覧へ戻る + 月ナビ + アクション */}
+        <div className="flex items-center justify-between">
+          <Link
+            href="/"
+            aria-label="月の一覧へ戻る"
+            className="inline-flex items-center gap-1 text-white/70 text-xs hover:text-white transition-colors"
+          >
+            <span>←</span>
+            <span>一覧へ</span>
+          </Link>
 
           <nav className="flex items-center gap-2" aria-label="月ナビゲーション">
             <button
@@ -173,31 +198,6 @@ export function HeroSection({
             </button>
           </nav>
 
-          <div className="flex items-center gap-3">
-            <button
-              type="button"
-              aria-label="テーマ切り替え"
-              onClick={() => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')}
-              className="text-white/70 hover:text-white transition-colors"
-            >
-              <Moon className="h-4 w-4" />
-            </button>
-            <button type="button" aria-label="設定" className="text-white/70 hover:text-white transition-colors">
-              <Settings className="h-4 w-4" />
-            </button>
-          </div>
-        </div>
-
-        {/* Sub Nav */}
-        <div className="flex items-center justify-between">
-          <Link
-            href="/"
-            aria-label="月の一覧へ戻る"
-            className="inline-flex items-center gap-1 text-white/70 text-xs hover:text-white transition-colors"
-          >
-            <span>←</span>
-            <span>一覧へ</span>
-          </Link>
           <div className="flex items-center gap-3">
             <CopyMonthDialog
               currentMonth={currentMonth}

--- a/src/components/sections/hero-section.tsx
+++ b/src/components/sections/hero-section.tsx
@@ -60,6 +60,7 @@ export function HeroSection({
 }: HeroSectionProps) {
   const router = useRouter()
   const { setTheme, resolvedTheme } = useTheme()
+  const isDark = resolvedTheme === 'dark'
   const direction = useMonthDirection(currentMonth)
   const previousMonth = getPreviousMonth(currentMonth)
 
@@ -92,18 +93,31 @@ export function HeroSection({
     <section
       className="relative overflow-hidden"
       style={{
-        background: `
-          linear-gradient(to bottom, transparent 65%, #FAFBFCAA 85%, #FAFBFC 100%),
-          radial-gradient(at 0% 0%, #3454D1 0%, transparent 50%),
-          radial-gradient(at 50% 0%, #4C3BCF 0%, transparent 50%),
-          radial-gradient(at 100% 0%, #3B82F6 0%, transparent 50%),
-          radial-gradient(at 0% 50%, #6366F1 0%, transparent 50%),
-          radial-gradient(at 50% 50%, #5B8DEF 0%, transparent 50%),
-          radial-gradient(at 100% 50%, #38BDF8 0%, transparent 50%),
-          radial-gradient(at 0% 100%, #C7D2FE 0%, transparent 50%),
-          radial-gradient(at 50% 100%, #DBEAFE 0%, transparent 50%),
-          radial-gradient(at 100% 100%, #BAE6FD 0%, transparent 50%)
-        `,
+        background: isDark
+          ? `
+            linear-gradient(to bottom, transparent 65%, #0F1117AA 85%, #0F1117 100%),
+            radial-gradient(at 0% 0%, #1E2A6E 0%, transparent 50%),
+            radial-gradient(at 50% 0%, #2A1F6E 0%, transparent 50%),
+            radial-gradient(at 100% 0%, #1E3A8A 0%, transparent 50%),
+            radial-gradient(at 0% 50%, #312E81 0%, transparent 50%),
+            radial-gradient(at 50% 50%, #2E4A8E 0%, transparent 50%),
+            radial-gradient(at 100% 50%, #1E5A8A 0%, transparent 50%),
+            radial-gradient(at 0% 100%, #1E1B4B 0%, transparent 50%),
+            radial-gradient(at 50% 100%, #172554 0%, transparent 50%),
+            radial-gradient(at 100% 100%, #164E63 0%, transparent 50%)
+          `
+          : `
+            linear-gradient(to bottom, transparent 65%, #FAFBFCAA 85%, #FAFBFC 100%),
+            radial-gradient(at 0% 0%, #3454D1 0%, transparent 50%),
+            radial-gradient(at 50% 0%, #4C3BCF 0%, transparent 50%),
+            radial-gradient(at 100% 0%, #3B82F6 0%, transparent 50%),
+            radial-gradient(at 0% 50%, #6366F1 0%, transparent 50%),
+            radial-gradient(at 50% 50%, #5B8DEF 0%, transparent 50%),
+            radial-gradient(at 100% 50%, #38BDF8 0%, transparent 50%),
+            radial-gradient(at 0% 100%, #C7D2FE 0%, transparent 50%),
+            radial-gradient(at 50% 100%, #DBEAFE 0%, transparent 50%),
+            radial-gradient(at 100% 100%, #BAE6FD 0%, transparent 50%)
+          `,
       }}
     >
       {/* 装飾blob */}
@@ -224,19 +238,19 @@ export function HeroSection({
         {/* Mini Cards */}
         <div className="flex gap-2.5">
           {/* Allowance */}
-          <div className="flex-1 rounded-[12px] bg-white shadow-sm p-3">
-            <span className="text-[9px] font-medium tracking-[0.5px] text-[#94A3B8] uppercase block">
+          <div className="flex-1 rounded-[12px] bg-card shadow-sm p-3">
+            <span className="text-[9px] font-medium tracking-[0.5px] text-muted-foreground uppercase block">
               Allowance / お小遣い
             </span>
             <AnimatedYen
               value={result.allowance}
-              className="text-lg font-bold font-mono text-[#1A1A1A] mt-1 block"
+              className="text-lg font-bold font-mono text-foreground mt-1 block"
             />
           </div>
 
           {/* Settlement */}
-          <div className="flex-1 rounded-[12px] bg-white shadow-sm p-3">
-            <span className="text-[9px] font-medium tracking-[0.5px] text-[#94A3B8] uppercase block">
+          <div className="flex-1 rounded-[12px] bg-card shadow-sm p-3">
+            <span className="text-[9px] font-medium tracking-[0.5px] text-muted-foreground uppercase block">
               Settlement / 精算額
             </span>
             {result.settlement !== 0 ? (
@@ -244,14 +258,14 @@ export function HeroSection({
                 <AnimatedYen
                   value={result.settlement}
                   absolute
-                  className="text-lg font-bold font-mono text-[#1A1A1A]"
+                  className="text-lg font-bold font-mono text-foreground"
                 />
-                <span className="inline-flex items-center px-1.5 py-0.5 rounded-lg bg-[#EFF6FF] text-[8px] font-semibold text-[#2563EB]">
+                <span className="inline-flex items-center px-1.5 py-0.5 rounded-lg bg-accent/10 text-[8px] font-semibold text-accent">
                   夫 → 妻
                 </span>
               </div>
             ) : (
-              <span className="text-lg font-bold font-mono text-[#999999] mt-1 block">
+              <span className="text-lg font-bold font-mono text-muted-foreground mt-1 block">
                 精算なし
               </span>
             )}

--- a/src/components/sections/hero-section.tsx
+++ b/src/components/sections/hero-section.tsx
@@ -259,7 +259,7 @@ export function HeroSection({
         </div>
 
         {children && (
-          <div className="px-5 pt-2 pb-4">
+          <div className="pt-2 pb-4">
             {children}
           </div>
         )}

--- a/src/components/sections/hero-section.tsx
+++ b/src/components/sections/hero-section.tsx
@@ -3,11 +3,12 @@
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
-import { ChevronLeft, ChevronRight, Moon, Settings, LogOut } from 'lucide-react'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { AnimatePresence, motion } from 'motion/react'
 import { AnimatedYen } from '@/components/animations/animated-number'
 import { CopyMonthDialog } from '@/components/features/copy-month-dialog'
 import { ExportCsvButton } from '@/components/features/export-csv-button'
+import { HeaderActions } from '@/components/layout/header-actions'
 import { useTheme } from 'next-themes'
 import { labelSlide, motionDuration, motionEase } from '@/components/animations/tokens'
 import { calculateSettlement, filterCarryoverExpenses, filterClearedCarryovers } from '@/lib/utils/calculation'
@@ -59,7 +60,7 @@ export function HeroSection({
   children,
 }: HeroSectionProps) {
   const router = useRouter()
-  const { setTheme, resolvedTheme } = useTheme()
+  const { resolvedTheme } = useTheme()
   const isDark = resolvedTheme === 'dark'
   const direction = useMonthDirection(currentMonth)
   const previousMonth = getPreviousMonth(currentMonth)
@@ -131,19 +132,7 @@ export function HeroSection({
           <span className="text-[12px] font-bold tracking-[1px] text-white uppercase">
             Score Splitter
           </span>
-          <div className="flex items-center gap-3">
-            <button
-              type="button"
-              aria-label="テーマ切り替え"
-              onClick={() => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')}
-              className="text-white/70 hover:text-white transition-colors"
-            >
-              <Moon className="h-4 w-4" />
-            </button>
-            <button type="button" aria-label="設定" className="text-white/70 hover:text-white transition-colors">
-              <Settings className="h-4 w-4" />
-            </button>
-          </div>
+          <HeaderActions variant="hero" />
         </div>
 
         {/* Nav — 一覧へ戻る + 月ナビ */}

--- a/src/components/sections/hero-section.tsx
+++ b/src/components/sections/hero-section.tsx
@@ -1,0 +1,261 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { ChevronLeft, ChevronRight, Moon, Settings, LogOut } from 'lucide-react'
+import { AnimatePresence, motion } from 'motion/react'
+import { AnimatedYen } from '@/components/animations/animated-number'
+import { CopyMonthDialog } from '@/components/features/copy-month-dialog'
+import { ExportCsvButton } from '@/components/features/export-csv-button'
+import { useTheme } from 'next-themes'
+import { labelSlide, motionDuration, motionEase } from '@/components/animations/tokens'
+import { calculateSettlement, filterCarryoverExpenses, filterClearedCarryovers } from '@/lib/utils/calculation'
+import { calculateMonthBalance } from '@/lib/utils/monthly-summary'
+import { formatCurrency, formatMonth, getPreviousMonth, parseMonth } from '@/lib/utils/format'
+import type { Income, Expense, Carryover, MonthlySummary } from '@/types'
+
+interface HeroSectionProps {
+  currentMonth: string
+  incomes: Income[]
+  expenses: Expense[]
+  carryovers: Carryover[]
+  recentSummaries: MonthlySummary[]
+}
+
+function useMonthDirection(currentMonth: string) {
+  const [state, setState] = useState({ prev: currentMonth, direction: 0 })
+  if (state.prev !== currentMonth) {
+    setState({
+      prev: currentMonth,
+      direction: currentMonth > state.prev ? 1 : -1,
+    })
+  }
+  return state.direction
+}
+
+const monthLabelVariants = {
+  enter: (d: number) => ({ x: d * labelSlide, opacity: 0 }),
+  center: { x: 0, opacity: 1 },
+  exit: (d: number) => ({ x: d * -labelSlide, opacity: 0 }),
+}
+
+function formatMonthDot(month: string): string {
+  return `${month.slice(0, 4)}.${month.slice(4, 6)}`
+}
+
+function getDaysInMonth(month: string): number {
+  const year = parseInt(month.slice(0, 4), 10)
+  const m = parseInt(month.slice(4, 6), 10)
+  return new Date(year, m, 0).getDate()
+}
+
+export function HeroSection({
+  currentMonth,
+  incomes,
+  expenses,
+  carryovers,
+}: HeroSectionProps) {
+  const router = useRouter()
+  const { setTheme, resolvedTheme } = useTheme()
+  const direction = useMonthDirection(currentMonth)
+  const previousMonth = getPreviousMonth(currentMonth)
+
+  const result = calculateSettlement(incomes, expenses, carryovers)
+  const { expenseTotal: allExpenseTotal, balance: monthlyBalance } =
+    calculateMonthBalance(incomes, expenses)
+
+  const carryoverExpenses = filterCarryoverExpenses(expenses)
+  const clearedCarryovers = filterClearedCarryovers(carryovers)
+  const carryoverExpenseTotal = carryoverExpenses.reduce((sum, e) => sum + e.amount, 0)
+  const clearedCarryoverTotal = clearedCarryovers.reduce((sum, c) => sum + c.amount, 0)
+  const hasAdjustments = carryoverExpenses.length > 0 || clearedCarryovers.length > 0
+
+  const totalItems = incomes.length + expenses.length
+  const days = getDaysInMonth(currentMonth)
+  const m = parseInt(currentMonth.slice(4, 6), 10)
+
+  function navigateMonth(offset: number) {
+    const year = parseInt(currentMonth.slice(0, 4), 10)
+    const month = parseInt(currentMonth.slice(4, 6), 10)
+    const date = new Date(year, month - 1 + offset, 1)
+    router.push(`/?month=${parseMonth(date)}`)
+  }
+
+  function goToCurrentMonth() {
+    router.push(`/?month=${parseMonth(new Date())}`)
+  }
+
+  return (
+    <section
+      className="relative overflow-hidden rounded-t-[20px]"
+      style={{
+        background: `
+          linear-gradient(to bottom, transparent 55%, #FAFBFCAA 80%, #FAFBFC 100%),
+          radial-gradient(at 0% 0%, #3454D1 0%, transparent 50%),
+          radial-gradient(at 50% 0%, #4C3BCF 0%, transparent 50%),
+          radial-gradient(at 100% 0%, #3B82F6 0%, transparent 50%),
+          radial-gradient(at 0% 50%, #6366F1 0%, transparent 50%),
+          radial-gradient(at 50% 50%, #5B8DEF 0%, transparent 50%),
+          radial-gradient(at 100% 50%, #38BDF8 0%, transparent 50%),
+          radial-gradient(at 0% 100%, #C7D2FE 0%, transparent 50%),
+          radial-gradient(at 50% 100%, #DBEAFE 0%, transparent 50%),
+          radial-gradient(at 100% 100%, #BAE6FD 0%, transparent 50%)
+        `,
+      }}
+    >
+      {/* 装飾blob */}
+      <div className="absolute w-[180px] h-[180px] rounded-full bg-white opacity-[0.06] right-[-20px] top-[-40px] pointer-events-none" />
+      <div className="absolute w-[120px] h-[120px] rounded-full bg-white opacity-[0.05] left-[-30px] top-[140px] pointer-events-none" />
+      <div className="absolute w-[80px] h-[80px] rounded-full bg-[#A5B4FC] opacity-[0.08] right-[20px] bottom-[200px] pointer-events-none" />
+
+      <div className="relative flex flex-col gap-3 pt-4 px-5 pb-7">
+        {/* Top Bar */}
+        <div className="flex items-center justify-between">
+          <span className="text-[13px] font-bold tracking-[1.5px] text-white">
+            SPLITTER
+          </span>
+
+          <nav className="flex items-center gap-2" aria-label="月ナビゲーション">
+            <button
+              type="button"
+              aria-label="前月に移動"
+              onClick={() => navigateMonth(-1)}
+              className="text-white/80 hover:text-white transition-colors"
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </button>
+            <button
+              type="button"
+              onClick={goToCurrentMonth}
+              aria-label="今月に移動"
+              aria-live="polite"
+              className="text-[13px] font-semibold text-white min-w-[90px] text-center overflow-hidden"
+            >
+              <AnimatePresence mode="wait" initial={false} custom={direction}>
+                <motion.span
+                  key={currentMonth}
+                  custom={direction}
+                  variants={monthLabelVariants}
+                  initial="enter"
+                  animate="center"
+                  exit="exit"
+                  transition={{ duration: motionDuration.fast, ease: motionEase.out }}
+                  className="inline-block"
+                >
+                  {formatMonth(currentMonth)}
+                </motion.span>
+              </AnimatePresence>
+            </button>
+            <button
+              type="button"
+              aria-label="翌月に移動"
+              onClick={() => navigateMonth(1)}
+              className="text-white/80 hover:text-white transition-colors"
+            >
+              <ChevronRight className="h-4 w-4" />
+            </button>
+          </nav>
+
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              aria-label="テーマ切り替え"
+              onClick={() => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')}
+              className="text-white/70 hover:text-white transition-colors"
+            >
+              <Moon className="h-4 w-4" />
+            </button>
+            <button type="button" aria-label="設定" className="text-white/70 hover:text-white transition-colors">
+              <Settings className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+
+        {/* Sub Nav */}
+        <div className="flex items-center justify-between">
+          <Link
+            href="/"
+            aria-label="月の一覧へ戻る"
+            className="inline-flex items-center gap-1 text-white/70 text-xs hover:text-white transition-colors"
+          >
+            <span>←</span>
+            <span>一覧へ</span>
+          </Link>
+          <div className="flex items-center gap-3">
+            <CopyMonthDialog
+              currentMonth={currentMonth}
+              previousMonth={previousMonth}
+            />
+            <ExportCsvButton
+              currentMonth={currentMonth}
+              incomes={incomes}
+              expenses={expenses}
+              carryovers={carryovers}
+            />
+          </div>
+        </div>
+
+        {/* 区切り線 */}
+        <div className="h-px bg-white/10 w-full" />
+
+        {/* Balance */}
+        <div className="flex flex-col items-center gap-1.5 py-3">
+          <span className="text-[10px] font-semibold tracking-[0.8px] text-white/70 uppercase">
+            Balance / 月の収支
+          </span>
+          <span className="text-sm font-medium font-mono text-white/50">
+            {formatMonthDot(currentMonth)}
+          </span>
+          <AnimatedYen
+            value={monthlyBalance}
+            className="text-4xl font-bold font-mono text-white tracking-tight"
+          />
+          <span className="text-[11px] text-white/70">
+            収入 {formatCurrency(result.totalIncome)} − 支出 {formatCurrency(Math.abs(allExpenseTotal))}
+          </span>
+          <span className="inline-flex items-center px-2.5 py-1 rounded-full bg-white/10 text-[10px] text-white/80">
+            {m}月1日 — {days}日間 / {totalItems}件の取引
+          </span>
+        </div>
+
+        {/* Mini Cards */}
+        <div className="flex gap-2.5">
+          {/* Allowance */}
+          <div className="flex-1 rounded-[12px] bg-white shadow-sm p-3">
+            <span className="text-[9px] font-medium tracking-[0.5px] text-[#94A3B8] uppercase block">
+              Allowance / お小遣い
+            </span>
+            <AnimatedYen
+              value={result.allowance}
+              className="text-lg font-bold font-mono text-[#1A1A1A] mt-1 block"
+            />
+          </div>
+
+          {/* Settlement */}
+          <div className="flex-1 rounded-[12px] bg-white shadow-sm p-3">
+            <span className="text-[9px] font-medium tracking-[0.5px] text-[#94A3B8] uppercase block">
+              Settlement / 精算額
+            </span>
+            {result.settlement !== 0 ? (
+              <div className="flex items-center gap-2 mt-1">
+                <AnimatedYen
+                  value={result.settlement}
+                  absolute
+                  className="text-lg font-bold font-mono text-[#1A1A1A]"
+                />
+                <span className="inline-flex items-center px-1.5 py-0.5 rounded-lg bg-[#EFF6FF] text-[8px] font-semibold text-[#2563EB]">
+                  夫 → 妻
+                </span>
+              </div>
+            ) : (
+              <span className="text-lg font-bold font-mono text-[#999999] mt-1 block">
+                精算なし
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/sections/hero-section.tsx
+++ b/src/components/sections/hero-section.tsx
@@ -21,6 +21,7 @@ interface HeroSectionProps {
   expenses: Expense[]
   carryovers: Carryover[]
   recentSummaries: MonthlySummary[]
+  children?: React.ReactNode
 }
 
 function useMonthDirection(currentMonth: string) {
@@ -55,6 +56,7 @@ export function HeroSection({
   incomes,
   expenses,
   carryovers,
+  children,
 }: HeroSectionProps) {
   const router = useRouter()
   const { setTheme, resolvedTheme } = useTheme()
@@ -91,7 +93,7 @@ export function HeroSection({
       className="relative overflow-hidden"
       style={{
         background: `
-          linear-gradient(to bottom, transparent 55%, #FAFBFCAA 80%, #FAFBFC 100%),
+          linear-gradient(to bottom, transparent 65%, #FAFBFCAA 85%, #FAFBFC 100%),
           radial-gradient(at 0% 0%, #3454D1 0%, transparent 50%),
           radial-gradient(at 50% 0%, #4C3BCF 0%, transparent 50%),
           radial-gradient(at 100% 0%, #3B82F6 0%, transparent 50%),
@@ -255,6 +257,12 @@ export function HeroSection({
             )}
           </div>
         </div>
+
+        {children && (
+          <div className="px-5 pt-2 pb-4">
+            {children}
+          </div>
+        )}
       </div>
     </section>
   )

--- a/src/components/sections/hero-section.tsx
+++ b/src/components/sections/hero-section.tsx
@@ -146,18 +146,18 @@ export function HeroSection({
           </div>
         </div>
 
-        {/* Nav — 一覧へ戻る + 月ナビ + アクション */}
+        {/* Nav — 一覧へ戻る + 月ナビ */}
         <div className="flex items-center justify-between">
           <Link
             href="/"
             aria-label="月の一覧へ戻る"
-            className="inline-flex items-center gap-1 text-white/70 text-xs hover:text-white transition-colors"
+            className="inline-flex items-center gap-1 text-white/70 text-xs hover:text-white transition-colors shrink-0"
           >
             <span>←</span>
             <span>一覧へ</span>
           </Link>
 
-          <nav className="flex items-center gap-2" aria-label="月ナビゲーション">
+          <nav className="flex items-center gap-1" aria-label="月ナビゲーション">
             <button
               type="button"
               aria-label="前月に移動"
@@ -171,7 +171,7 @@ export function HeroSection({
               onClick={goToCurrentMonth}
               aria-label="今月に移動"
               aria-live="polite"
-              className="text-[13px] font-semibold text-white min-w-[90px] text-center overflow-hidden"
+              className="text-[13px] font-semibold text-white min-w-[80px] text-center overflow-hidden"
             >
               <AnimatePresence mode="wait" initial={false} custom={direction}>
                 <motion.span
@@ -198,7 +198,7 @@ export function HeroSection({
             </button>
           </nav>
 
-          <div className="flex items-center gap-3">
+          <div className="flex items-center gap-2 shrink-0">
             <CopyMonthDialog
               currentMonth={currentMonth}
               previousMonth={previousMonth}
@@ -211,6 +211,7 @@ export function HeroSection({
             />
           </div>
         </div>
+
 
         {/* 区切り線 */}
         <div className="h-px bg-white/10 w-full" />

--- a/src/components/sections/income-section.tsx
+++ b/src/components/sections/income-section.tsx
@@ -20,18 +20,18 @@ export function IncomeSection({ incomes, month }: IncomeSectionProps) {
 
   return (
     <div data-section="income">
-      <div className="flex items-baseline justify-between border-b border-foreground pb-2.5 mb-1">
-        <h3 className="text-[11px] md:text-sm font-bold tracking-[0.16em] uppercase">
+      <div className="flex items-baseline justify-between pb-2 mb-1">
+        <h3 className="text-[12px] font-bold tracking-[0.10em] uppercase">
           Income / 収入
         </h3>
-        <span className="text-[10px] md:text-xs text-sub-text font-tabular">
+        <span className="text-[10px] text-sub-text font-tabular">
           {incomes.length}件
         </span>
       </div>
 
-      <div>
+      <div className="rounded-[18px] bg-card shadow-soft overflow-hidden">
         <AnimatePresence initial={false}>
-          {incomes.map((income) => (
+          {incomes.map((income, i) => (
             <motion.div
               key={income.id}
               data-testid="item-row"
@@ -40,16 +40,23 @@ export function IncomeSection({ incomes, month }: IncomeSectionProps) {
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, x: -8, transition: listExit }}
               transition={listSpring}
-              className="group grid grid-cols-[24px_1fr_auto] gap-3 py-3 border-b border-border items-baseline"
+              className={`group grid grid-cols-[32px_1fr_auto] gap-3 px-3.5 py-3 items-center ${
+                i < incomes.length - 1 ? 'border-b border-border' : ''
+              }`}
             >
-              <span className="text-[10px] font-bold text-husband group-[:nth-child(odd)]:text-husband group-[:nth-child(even)]:text-wife"
-                style={{ color: `var(--${income.person})` }}
+              <span
+                className="w-7 h-7 rounded-full text-white text-[11px] font-bold inline-flex items-center justify-center shrink-0"
+                style={{
+                  background: income.person === 'husband'
+                    ? 'linear-gradient(135deg, oklch(0.65 0.16 250), oklch(0.55 0.18 260))'
+                    : 'linear-gradient(135deg, oklch(0.75 0.16 350), oklch(0.65 0.18 20))',
+                }}
               >
                 {income.person === 'husband' ? '夫' : '妻'}
               </span>
-              <span className="text-sm md:text-base font-medium truncate">{income.label}</span>
+              <span className="text-sm font-medium truncate">{income.label}</span>
               <div className="flex items-center gap-1">
-                <span className="text-sm md:text-base font-semibold font-tabular text-neon-green">
+                <span className="text-sm font-semibold font-tabular text-neon-green">
                   +{formatCurrency(income.amount).slice(1)}
                 </span>
                 <div className="flex items-center gap-0.5 md:opacity-0 md:group-hover:opacity-100 transition-opacity">
@@ -81,19 +88,19 @@ export function IncomeSection({ incomes, month }: IncomeSectionProps) {
             <p className="text-xs">収入がありません</p>
           </div>
         )}
-      </div>
 
-      <div className="pb-4">
-        <AddEntryModal type="income" month={month} />
-      </div>
+        <div className="border-t border-border bg-[var(--surface-total)] px-3.5 py-2.5">
+          <AddEntryModal type="income" month={month} />
+        </div>
 
-      <div className="flex items-baseline justify-between pt-4 border-t-2 border-foreground">
-        <span className="text-[10px] md:text-[11px] font-bold tracking-[0.16em] uppercase text-sub-text">
-          Total
-        </span>
-        <span className="text-xl md:text-[28px] font-bold font-tabular tracking-[-0.02em] text-neon-green">
-          {formatCurrency(total)}
-        </span>
+        <div className="flex items-baseline justify-between px-3.5 py-3 border-t border-border bg-[var(--surface-total)]">
+          <span className="text-[10px] font-bold tracking-[0.14em] uppercase text-sub-text">
+            Total
+          </span>
+          <span className="text-lg font-bold font-tabular tracking-[-0.01em] text-neon-green">
+            {formatCurrency(total)}
+          </span>
+        </div>
       </div>
     </div>
   )

--- a/src/components/sections/income-section.tsx
+++ b/src/components/sections/income-section.tsx
@@ -48,8 +48,8 @@ export function IncomeSection({ incomes, month }: IncomeSectionProps) {
                 className="w-7 h-7 rounded-full text-white text-[11px] font-bold inline-flex items-center justify-center shrink-0"
                 style={{
                   background: income.person === 'husband'
-                    ? 'linear-gradient(135deg, oklch(0.65 0.16 250), oklch(0.55 0.18 260))'
-                    : 'linear-gradient(135deg, oklch(0.75 0.16 350), oklch(0.65 0.18 20))',
+                    ? 'var(--gradient-husband)'
+                    : 'var(--gradient-wife)',
                 }}
               >
                 {income.person === 'husband' ? '夫' : '妻'}

--- a/src/components/sections/income-section.tsx
+++ b/src/components/sections/income-section.tsx
@@ -21,15 +21,16 @@ export function IncomeSection({ incomes, month }: IncomeSectionProps) {
   return (
     <div data-section="income">
       <div className="flex items-baseline justify-between pb-2 mb-1">
-        <h3 className="text-[12px] font-bold tracking-[0.10em] uppercase">
+        <h3 className="text-[11px] font-bold tracking-[0.8px] text-foreground uppercase">
           Income / 収入
         </h3>
-        <span className="text-[10px] text-sub-text font-tabular">
+        <span className="text-[11px] text-[#999999]">
           {incomes.length}件
         </span>
       </div>
 
       <div className="rounded-[18px] bg-card shadow-soft overflow-hidden">
+        <div className="border-b border-[#E5E7EB]" />
         <AnimatePresence initial={false}>
           {incomes.map((income, i) => (
             <motion.div
@@ -40,23 +41,20 @@ export function IncomeSection({ incomes, month }: IncomeSectionProps) {
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, x: -8, transition: listExit }}
               transition={listSpring}
-              className={`group grid grid-cols-[32px_1fr_auto] gap-3 px-3.5 py-3 items-center ${
+              className={`group grid grid-cols-[22px_1fr_auto] gap-3 px-3.5 py-3 items-center ${
                 i < incomes.length - 1 ? 'border-b border-border' : ''
               }`}
             >
               <span
-                className="w-7 h-7 rounded-full text-white text-[11px] font-bold inline-flex items-center justify-center shrink-0"
-                style={{
-                  background: income.person === 'husband'
-                    ? 'var(--gradient-husband)'
-                    : 'var(--gradient-wife)',
-                }}
+                className={`w-[22px] h-[22px] rounded-full text-white text-[8px] font-bold inline-flex items-center justify-center shrink-0 ${
+                  income.person === 'husband' ? 'bg-husband' : 'bg-wife'
+                }`}
               >
                 {income.person === 'husband' ? '夫' : '妻'}
               </span>
-              <span className="text-sm font-medium truncate">{income.label}</span>
+              <span className="text-[13px] font-medium truncate">{income.label}</span>
               <div className="flex items-center gap-1">
-                <span className="text-sm font-semibold font-tabular text-neon-green">
+                <span className="font-mono text-[13px] font-semibold text-[#2563EB]">
                   +{formatCurrency(income.amount).slice(1)}
                 </span>
                 <div className="flex items-center gap-0.5 md:opacity-0 md:group-hover:opacity-100 transition-opacity">
@@ -94,10 +92,10 @@ export function IncomeSection({ incomes, month }: IncomeSectionProps) {
         </div>
 
         <div className="flex items-baseline justify-between px-3.5 py-3 border-t border-border bg-[var(--surface-total)]">
-          <span className="text-[10px] font-bold tracking-[0.14em] uppercase text-sub-text">
+          <span className="text-[11px] text-[#999999] font-semibold tracking-[0.8px] uppercase">
             Total
           </span>
-          <span className="text-lg font-bold font-tabular tracking-[-0.01em] text-neon-green">
+          <span className="font-mono text-[15px] font-bold text-[#2563EB]">
             {formatCurrency(total)}
           </span>
         </div>

--- a/src/components/sections/monthly-list-section.tsx
+++ b/src/components/sections/monthly-list-section.tsx
@@ -2,8 +2,8 @@
 
 import { useState } from 'react'
 import Link from 'next/link'
-import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { MonthRow } from '@/components/features/month-row'
+import { YearlyBarChart } from '@/components/charts/yearly-bar-chart'
 import { formatCurrency, parseMonth } from '@/lib/utils/format'
 import type { MonthlySummary } from '@/types'
 
@@ -30,6 +30,8 @@ export function MonthlyListSection({ summaries }: MonthlyListSectionProps) {
     )
   }
 
+  const availableYears = [...new Set(summaries.map((s) => Number(s.month.slice(0, 4))))].sort()
+
   const yearSummaries = summaries.filter((s) =>
     s.month.startsWith(String(selectedYear))
   )
@@ -50,9 +52,8 @@ export function MonthlyListSection({ summaries }: MonthlyListSectionProps) {
     }
   })
 
-  const maxIncome = Math.max(...yearSummaries.map((s) => s.incomeTotal), 1)
-  const maxExpense = Math.max(
-    ...yearSummaries.map((s) => Math.abs(s.expenseTotal)),
+  const maxBalance = Math.max(
+    ...yearSummaries.map((s) => Math.abs(s.balance)),
     1
   )
 
@@ -60,61 +61,64 @@ export function MonthlyListSection({ summaries }: MonthlyListSectionProps) {
 
   return (
     <section aria-label="月の一覧">
-      {/* タイトルバー */}
+      {/* セクションヘッド */}
       <div className="pb-4">
-        <div className="text-[10px] font-bold tracking-[0.22em] uppercase text-sub-text">
+        <div className="text-[11px] font-medium tracking-[0.5px] text-[#999999] uppercase">
           Months / 月一覧
         </div>
-        <div className="text-[32px] font-bold tracking-[-0.03em] font-tabular mt-1.5 leading-none">
-          {selectedYear}
+        <div className="flex items-center gap-3 mt-1.5">
+          <div className="text-4xl font-bold leading-none">
+            {selectedYear}
+          </div>
+          {/* pill型セレクター */}
+          <select
+            value={selectedYear}
+            onChange={(e) => setSelectedYear(Number(e.target.value))}
+            className="rounded-lg border border-[#E5E7EB] px-3 py-1.5 text-sm font-medium bg-transparent appearance-none cursor-pointer"
+            aria-label="年を選択"
+            style={{ backgroundImage: 'none' }}
+          >
+            {availableYears.map((y) => (
+              <option key={y} value={y}>{y}</option>
+            ))}
+          </select>
+          <span className="text-sm text-[#999999]">▾</span>
         </div>
-        <p className="text-xs text-sub-text mt-2">
+        <p className="text-[13px] text-[#999999] mt-2">
           {recordedCount > 0
             ? `${recordedCount}ヶ月分の記録があります`
             : 'この年の記録はまだありません'}
         </p>
       </div>
 
-      {/* 年ナビゲーション */}
-      <div className="flex items-center justify-between pb-4">
-        <button
-          type="button"
-          onClick={() => setSelectedYear((y) => y - 1)}
-          className="w-8 h-8 rounded-full bg-muted flex items-center justify-center text-sm text-accent transition-colors"
-          aria-label="前年に移動"
-        >
-          <ChevronLeft className="h-3.5 w-3.5" />
-        </button>
-        <div className="px-4 py-1.5 rounded-full bg-card shadow-soft text-sm font-semibold font-tabular">
-          {selectedYear}
-        </div>
-        <button
-          type="button"
-          onClick={() => setSelectedYear((y) => y + 1)}
-          className="w-8 h-8 rounded-full bg-muted flex items-center justify-center text-sm text-accent transition-colors"
-          aria-label="翌年に移動"
-        >
-          <ChevronRight className="h-3.5 w-3.5" />
-        </button>
-      </div>
-
-      {/* 年間サマリー */}
+      {/* Year-to-Date カード */}
       {recordedCount > 0 && (
-        <div className="rounded-[18px] shadow-soft p-4">
-          <div className="text-[11px] text-sub-text font-medium">Year-to-date</div>
-          <div className="flex items-baseline mt-1">
+        <div className="rounded-[16px] shadow-soft p-5">
+          <div className="text-[10px] font-medium tracking-[0.5px] text-[#999999] uppercase">
+            Year-to-Date / 年間収支
+          </div>
+          <div className="mt-1">
             <span
-              className={`text-[26px] font-bold tracking-[-0.03em] font-tabular ${
-                isBalancePositive ? 'text-accent' : 'text-neon-red'
+              className={`font-mono text-[28px] font-bold ${
+                isBalancePositive ? 'text-[#2563EB]' : 'text-[#E2483D]'
               }`}
             >
               {isBalancePositive ? '+' : ''}
               {balanceYTD.toLocaleString('ja-JP')}
             </span>
-            <span className="text-xs text-sub-text ml-1">円</span>
           </div>
-          <div className="text-[11px] text-sub-text mt-1">
-            {recordedCount}ヶ月分 · 収入 {formatCurrency(incomeYTD)} · 支出 {formatCurrency(expenseYTD)}
+          <div className="flex items-center gap-3 mt-1">
+            <span className="font-mono text-[11px] font-medium text-[#666666]">
+              Income {formatCurrency(incomeYTD)}
+            </span>
+            <span className="font-mono text-[11px] font-medium text-[#666666]">
+              Expense {formatCurrency(expenseYTD)}
+            </span>
+          </div>
+
+          {/* 年間バーチャート */}
+          <div className="mt-4">
+            <YearlyBarChart summaries={yearSummaries} year={selectedYear} />
           </div>
         </div>
       )}
@@ -124,18 +128,18 @@ export function MonthlyListSection({ summaries }: MonthlyListSectionProps) {
         ※各月の収支は繰越に回す前の金額です
       </p>
 
-      {/* 月一覧ヘッダー */}
+      {/* BY MONTH ヘッダー */}
       <div className="flex items-baseline justify-between py-2">
-        <span className="text-[11px] font-bold tracking-[0.16em] uppercase">
-          By month / 月別
+        <span className="text-[11px] font-medium tracking-[0.5px] text-[#999999] uppercase">
+          By Month / 月別
         </span>
-        <span className="text-[10px] text-sub-text font-tabular">
-          12 / {recordedCount} 件
+        <span className="text-[11px] text-[#999999]">
+          12ヶ月
         </span>
       </div>
 
       {/* 月リスト */}
-      <div className="flex flex-col gap-2">
+      <div className="flex flex-col">
         {allMonths.map((m) => (
           <MonthRow
             key={m.month}
@@ -143,8 +147,7 @@ export function MonthlyListSection({ summaries }: MonthlyListSectionProps) {
             index={m.index}
             summary={m.summary}
             isCurrentMonth={m.month === currentMonth}
-            maxIncome={maxIncome}
-            maxExpense={maxExpense}
+            maxBalance={maxBalance}
           />
         ))}
       </div>

--- a/src/components/sections/monthly-list-section.tsx
+++ b/src/components/sections/monthly-list-section.tsx
@@ -76,27 +76,22 @@ export function MonthlyListSection({ summaries }: MonthlyListSectionProps) {
       </div>
 
       {/* 年ナビゲーション */}
-      <div className="flex items-center justify-between pb-4 border-b border-border">
+      <div className="flex items-center justify-between pb-4">
         <button
           type="button"
           onClick={() => setSelectedYear((y) => y - 1)}
-          className="w-8 h-8 rounded-lg border border-border flex items-center justify-center text-sm bg-background hover:bg-muted/50 transition-colors"
+          className="w-8 h-8 rounded-full bg-muted flex items-center justify-center text-sm text-accent transition-colors"
           aria-label="前年に移動"
         >
           <ChevronLeft className="h-3.5 w-3.5" />
         </button>
-        <div className="text-center">
-          <div className="text-lg font-bold tracking-[-0.01em] font-tabular">
-            {selectedYear}
-          </div>
-          <div className="text-[10px] text-sub-text tracking-[0.12em] uppercase mt-0.5">
-            Year
-          </div>
+        <div className="px-4 py-1.5 rounded-full bg-card shadow-soft text-sm font-semibold font-tabular">
+          {selectedYear}
         </div>
         <button
           type="button"
           onClick={() => setSelectedYear((y) => y + 1)}
-          className="w-8 h-8 rounded-lg border border-border flex items-center justify-center text-sm bg-background hover:bg-muted/50 transition-colors"
+          className="w-8 h-8 rounded-full bg-muted flex items-center justify-center text-sm text-accent transition-colors"
           aria-label="翌年に移動"
         >
           <ChevronRight className="h-3.5 w-3.5" />
@@ -105,39 +100,21 @@ export function MonthlyListSection({ summaries }: MonthlyListSectionProps) {
 
       {/* 年間サマリー */}
       {recordedCount > 0 && (
-        <div className="py-5 border-b border-border">
-          <div className="text-[10px] font-bold tracking-[0.22em] uppercase text-sub-text">
-            Year-to-date / 年間収支
-          </div>
-          <div className="flex items-baseline mt-2">
+        <div className="rounded-[18px] shadow-soft p-4">
+          <div className="text-[11px] text-sub-text font-medium">Year-to-date</div>
+          <div className="flex items-baseline mt-1">
             <span
-              className={`text-[44px] font-bold tracking-[-0.04em] leading-[0.9] font-tabular ${
-                isBalancePositive ? 'text-neon-green' : 'text-neon-red'
+              className={`text-[26px] font-bold tracking-[-0.03em] font-tabular ${
+                isBalancePositive ? 'text-accent' : 'text-neon-red'
               }`}
             >
               {isBalancePositive ? '+' : ''}
               {balanceYTD.toLocaleString('ja-JP')}
             </span>
-            <span className="text-[13px] font-semibold text-sub-text ml-1">円</span>
+            <span className="text-xs text-sub-text ml-1">円</span>
           </div>
-
-          <div className="grid grid-cols-2 mt-4 border-t border-border">
-            <div className="py-3 pr-3.5 border-r border-border">
-              <div className="text-[9px] font-bold tracking-[0.2em] uppercase text-sub-text">
-                Income
-              </div>
-              <div className="text-[18px] font-bold tracking-[-0.02em] font-tabular mt-1">
-                {formatCurrency(incomeYTD)}
-              </div>
-            </div>
-            <div className="py-3 pl-3.5">
-              <div className="text-[9px] font-bold tracking-[0.2em] uppercase text-sub-text">
-                Expense
-              </div>
-              <div className="text-[18px] font-bold tracking-[-0.02em] font-tabular mt-1">
-                {formatCurrency(expenseYTD)}
-              </div>
-            </div>
+          <div className="text-[11px] text-sub-text mt-1">
+            {recordedCount}ヶ月分 · 収入 {formatCurrency(incomeYTD)} · 支出 {formatCurrency(expenseYTD)}
           </div>
         </div>
       )}
@@ -158,7 +135,7 @@ export function MonthlyListSection({ summaries }: MonthlyListSectionProps) {
       </div>
 
       {/* 月リスト */}
-      <div className="border-t border-foreground">
+      <div className="flex flex-col gap-2">
         {allMonths.map((m) => (
           <MonthRow
             key={m.month}

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -37,7 +37,7 @@ function DrawerOverlay({
     <DrawerPrimitive.Overlay
       data-slot="drawer-overlay"
       className={cn(
-        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        "fixed inset-0 z-50 bg-[#00000066] backdrop-blur-sm data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
         className
       )}
       {...props}
@@ -58,14 +58,14 @@ function DrawerContent({
         className={cn(
           "group/drawer-content fixed z-50 flex h-auto flex-col bg-background",
           "data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b",
-          "data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t",
+          "data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-[20px] data-[vaul-drawer-direction=bottom]:border-t",
           "data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm",
           "data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=left]:sm:max-w-sm",
           className
         )}
         {...props}
       >
-        <div className="mx-auto mt-4 hidden h-2 w-[100px] shrink-0 rounded-full bg-muted group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
+        <div className="mx-auto mt-4 hidden h-1 w-10 shrink-0 rounded-full bg-[#D9D9D9] group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
         {children}
       </DrawerPrimitive.Content>
     </DrawerPortal>

--- a/src/components/ui/person-badge.tsx
+++ b/src/components/ui/person-badge.tsx
@@ -2,24 +2,25 @@ import type { Person } from '@/types'
 
 interface PersonBadgeProps {
   person: Person
+  className?: string
 }
 
 const personConfig = {
   husband: {
     label: '夫',
-    className: 'bg-gradient-to-r from-husband-light to-husband-light/50 text-husband border border-husband/25',
+    className: 'bg-husband',
   },
   wife: {
     label: '妻',
-    className: 'bg-gradient-to-r from-wife-light to-wife-light/50 text-wife border border-wife/25',
+    className: 'bg-wife',
   },
 } as const
 
-export function PersonBadge({ person }: PersonBadgeProps) {
+export function PersonBadge({ person, className = '' }: PersonBadgeProps) {
   const config = personConfig[person]
 
   return (
-    <span className={`text-xs px-2 py-1 rounded-md font-semibold ${config.className}`}>
+    <span className={`w-[22px] h-[22px] rounded-full text-[8px] font-bold text-white inline-flex items-center justify-center shrink-0 ${config.className} ${className}`}>
       {config.label}
     </span>
   )

--- a/src/components/ui/person-selector.tsx
+++ b/src/components/ui/person-selector.tsx
@@ -19,7 +19,7 @@ export function PersonSelector({ value, onChange, name }: PersonSelectorProps) {
             key={p}
             type="button"
             onClick={() => onChange(p)}
-            className="flex-1 py-3 rounded-xl text-sm font-semibold text-center transition-colors"
+            className="flex-1 py-3 rounded-[14px] text-sm font-semibold text-center transition-colors"
             style={{
               background: active ? `var(--${p}-light)` : 'var(--card)',
               color: active ? `var(--${p})` : 'var(--sub-text)',

--- a/src/components/ui/person-selector.tsx
+++ b/src/components/ui/person-selector.tsx
@@ -19,12 +19,11 @@ export function PersonSelector({ value, onChange, name }: PersonSelectorProps) {
             key={p}
             type="button"
             onClick={() => onChange(p)}
-            className="flex-1 py-3 rounded-[14px] text-sm font-semibold text-center transition-colors"
-            style={{
-              background: active ? `var(--${p}-light)` : 'var(--card)',
-              color: active ? `var(--${p})` : 'var(--sub-text)',
-              border: active ? `1.5px solid var(--${p})` : '1px solid var(--border)',
-            }}
+            className={`flex-1 py-3 rounded-[14px] text-sm font-semibold text-center transition-colors border ${
+              active
+                ? 'bg-[#DBEAFE] text-[#3B82F6] border-[#3B82F6]'
+                : 'bg-[var(--card)] text-[var(--sub-text)] border-[var(--border)]'
+            }`}
           >
             {p === 'husband' ? '夫' : '妻'}
           </button>

--- a/src/components/ui/toggle-switch.tsx
+++ b/src/components/ui/toggle-switch.tsx
@@ -16,7 +16,7 @@ export function ToggleSwitch({
   name,
 }: ToggleSwitchProps) {
   return (
-    <div className="flex items-center justify-between py-3 px-3.5 rounded-xl border border-border bg-card">
+    <div className="flex items-center justify-between py-3 px-3.5 rounded-[14px] border border-input bg-[oklch(0.98_0.005_260)] dark:bg-muted">
       {name && <input type="hidden" name={name} value={String(checked)} />}
       <div>
         <div className="text-sm font-semibold">{label}</div>
@@ -29,7 +29,7 @@ export function ToggleSwitch({
         onClick={() => onChange(!checked)}
         className="relative w-11 h-[26px] rounded-full transition-colors shrink-0 ml-3"
         style={{
-          background: checked ? 'var(--neon-cyan)' : 'oklch(0.85 0.01 260)',
+          background: checked ? 'var(--accent)' : 'oklch(0.90 0.01 260)',
         }}
       >
         <span

--- a/src/components/ui/toggle-switch.tsx
+++ b/src/components/ui/toggle-switch.tsx
@@ -16,7 +16,7 @@ export function ToggleSwitch({
   name,
 }: ToggleSwitchProps) {
   return (
-    <div className="flex items-center justify-between py-3 px-3.5 rounded-[14px] border border-input bg-secondary dark:bg-muted">
+    <div className="flex items-center justify-between py-3 px-3.5 rounded-[12px] bg-[#F3F4F6]">
       {name && <input type="hidden" name={name} value={String(checked)} />}
       <div>
         <div className="text-sm font-semibold">{label}</div>

--- a/src/components/ui/toggle-switch.tsx
+++ b/src/components/ui/toggle-switch.tsx
@@ -16,7 +16,7 @@ export function ToggleSwitch({
   name,
 }: ToggleSwitchProps) {
   return (
-    <div className="flex items-center justify-between py-3 px-3.5 rounded-[14px] border border-input bg-[oklch(0.98_0.005_260)] dark:bg-muted">
+    <div className="flex items-center justify-between py-3 px-3.5 rounded-[14px] border border-input bg-secondary dark:bg-muted">
       {name && <input type="hidden" name={name} value={String(checked)} />}
       <div>
         <div className="text-sm font-semibold">{label}</div>
@@ -29,7 +29,7 @@ export function ToggleSwitch({
         onClick={() => onChange(!checked)}
         className="relative w-11 h-[26px] rounded-full transition-colors shrink-0 ml-3"
         style={{
-          background: checked ? 'var(--accent)' : 'oklch(0.90 0.01 260)',
+          background: checked ? 'var(--accent)' : 'var(--input)',
         }}
       >
         <span

--- a/tests/components/a11y/skip-link.test.tsx
+++ b/tests/components/a11y/skip-link.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 
 vi.mock('next/font/google', () => ({
-  Geist: () => ({ variable: '--font-geist-sans' }),
+  Inter: () => ({ variable: '--font-inter' }),
   Geist_Mono: () => ({ variable: '--font-geist-mono' }),
 }))
 

--- a/tests/components/a11y/viewport-meta.test.ts
+++ b/tests/components/a11y/viewport-meta.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 
 vi.mock('next/font/google', () => ({
-  Geist: () => ({ variable: '--font-geist-sans' }),
+  Inter: () => ({ variable: '--font-inter' }),
   Geist_Mono: () => ({ variable: '--font-geist-mono' }),
 }))
 

--- a/tests/components/sections/expense-section.test.tsx
+++ b/tests/components/sections/expense-section.test.tsx
@@ -108,9 +108,9 @@ describe('ExpenseSection', () => {
     // 繰越バッジが表示されない
     expect(screen.queryByText('繰越')).not.toBeInTheDocument()
 
-    // 金額がtext-neon-redクラスで表示される（U+2212 数学マイナス記号）
+    // 金額が支出色で表示される（U+2212 数学マイナス記号）
     const amountElement = screen.getByText('−¥50,000')
-    expect(amountElement).toHaveClass('text-neon-red')
+    expect(amountElement).toHaveClass('text-[#E2483D]')
   })
 
   it('ヘッダーに繰越件数を表示する', () => {

--- a/tests/e2e/household-flow.spec.ts
+++ b/tests/e2e/household-flow.spec.ts
@@ -119,8 +119,7 @@ test.describe('月詳細ページ', () => {
   })
 
   test('ヘッダーが表示される', async ({ page }) => {
-    await expect(page.locator('header').getByText('Splitter')).toBeVisible()
-    await expect(page.getByRole('button', { name: /ログアウト/ })).toBeVisible()
+    await expect(page.getByText('SPLITTER')).toBeVisible()
   })
 
   test('全セクションが表示される', async ({ page }) => {

--- a/tests/e2e/household-flow.spec.ts
+++ b/tests/e2e/household-flow.spec.ts
@@ -119,7 +119,7 @@ test.describe('月詳細ページ', () => {
   })
 
   test('ヘッダーが表示される', async ({ page }) => {
-    await expect(page.locator('header').getByText('Score Splitter')).toBeVisible()
+    await expect(page.locator('header').getByText('Splitter')).toBeVisible()
     await expect(page.getByRole('button', { name: /ログアウト/ })).toBeVisible()
   })
 


### PR DESCRIPTION
## Summary

- エディトリアル/ネオンスタイルから「Soft Cards」デザインへ全面移行
- 白背景・淡い水色グラデヒーローカード・角丸22px・優しいシャドウの柔らかいビジュアルに統一
- 銀行/自治体アプリ的な硬さを解消し、家計管理アプリにふさわしい親しみやすさを実現

### 変更ファイル（16ファイル）
- `globals.css`: 新トークン(shadow-soft, gradient-fab等)、glass削除、カラー調整
- `header.tsx`: glass-strong → 白背景、ナビボタンpill化
- `page.tsx` / `loading.tsx`: レイアウトをカードgap型に
- `calculation-section.tsx`: rounded-[22px]グラデヒーローカード + 第2階層カード化
- `income/expense/carryover-section.tsx`: リストをrounded-[18px]カード化、Person dotをグラデ丸に
- `add-entry-fab.tsx`: 黒丸 → グラデPill + テキスト「項目を追加」
- `login/page.tsx`: カードフォーム + グラデSubmitボタン
- `add-entry-sheet.tsx`: タブ色更新、Submit→グラデpill
- `month-row.tsx` / `monthly-list-section.tsx`: 月カードをrounded-[16px]シャドウ付きに
- `person-selector.tsx` / `toggle-switch.tsx`: ソフト化

## Test plan

- [x] `npm run build` — ビルド成功
- [x] `npm run lint` — 0エラー
- [x] `npm run test:run` — 全240テストパス
- [ ] ブラウザ確認: ログイン画面（グラデボタン、丸みinput）
- [ ] ブラウザ確認: ホーム月詳細（ヒーローカード、リストカード、FAB）
- [ ] ブラウザ確認: 月一覧（カード型月リスト）
- [ ] ブラウザ確認: ダークモード切替
- [ ] ブラウザ確認: モバイル表示（390px幅）
- [ ] ブラウザ確認: ボトムシート（FABタップ）