### PR TITLE
feat: ナビゲーションボタンに即時タップフィードバックを追加

### DIFF
--- a/src/components/features/month-row.tsx
+++ b/src/components/features/month-row.tsx
@@ -43,7 +43,7 @@ export function MonthRow({
     <Link
       href={monthToPath(month)}
       aria-label={`${formatMonth(month)}の詳細を開く`}
-      className="flex items-center gap-2.5 py-3.5 border-b border-border transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+      className="flex items-center gap-2.5 py-3.5 border-b border-border transition-[color,background-color,transform] active:scale-[0.99] active:bg-muted/50 outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
     >
       {/* 月番号 */}
       <span className="font-mono text-[11px] font-medium text-[#999999]">

--- a/src/components/layout/month-selector.tsx
+++ b/src/components/layout/month-selector.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useTransition } from 'react'
 import Link from 'next/link'
 import { AnimatePresence, motion } from 'motion/react'
 import { useRouter } from 'next/navigation'
@@ -38,17 +38,22 @@ const monthLabelVariants = {
 
 export function MonthSelector({ currentMonth, incomes, expenses, carryovers }: MonthSelectorProps) {
   const router = useRouter()
+  const [isPending, startTransition] = useTransition()
   const direction = useMonthDirection(currentMonth)
 
   function navigateMonth(offset: number) {
     const year = parseInt(currentMonth.slice(0, 4), 10)
     const month = parseInt(currentMonth.slice(4, 6), 10)
     const date = new Date(year, month - 1 + offset, 1)
-    router.push(monthToPath(parseMonth(date)))
+    startTransition(() => {
+      router.push(monthToPath(parseMonth(date)))
+    })
   }
 
   function goToCurrentMonth() {
-    router.push(monthToPath(parseMonth(new Date())))
+    startTransition(() => {
+      router.push(monthToPath(parseMonth(new Date())))
+    })
   }
 
   const previousMonth = getPreviousMonth(currentMonth)
@@ -61,13 +66,14 @@ export function MonthSelector({ currentMonth, incomes, expenses, carryovers }: M
           <span>一覧へ</span>
         </Link>
       </Button>
-      <div className="flex items-center gap-2">
-        <Button variant="outline" size="icon" aria-label="前月に移動" onClick={() => navigateMonth(-1)}>
+      <div className={`flex items-center gap-2 transition-opacity ${isPending ? 'opacity-50 pointer-events-none' : ''}`}>
+        <Button variant="outline" size="icon" aria-label="前月に移動" disabled={isPending} onClick={() => navigateMonth(-1)}>
           <ChevronLeft className="h-4 w-4" />
         </Button>
         <button
           type="button"
           onClick={goToCurrentMonth}
+          disabled={isPending}
           aria-label="今月に移動"
           aria-live="polite"
           className="text-2xl font-bold min-w-[140px] text-center hover:text-accent transition-[color,transform] duration-200 motion-safe:hover:scale-105 outline-none focus-visible:ring-2 focus-visible:ring-ring/50 rounded-md overflow-hidden"
@@ -87,7 +93,7 @@ export function MonthSelector({ currentMonth, incomes, expenses, carryovers }: M
             </motion.span>
           </AnimatePresence>
         </button>
-        <Button variant="outline" size="icon" aria-label="翌月に移動" onClick={() => navigateMonth(1)}>
+        <Button variant="outline" size="icon" aria-label="翌月に移動" disabled={isPending} onClick={() => navigateMonth(1)}>
           <ChevronRight className="h-4 w-4" />
         </Button>
       </div>

--- a/src/components/sections/monthly-list-section.tsx
+++ b/src/components/sections/monthly-list-section.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useTransition } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { MonthRow } from '@/components/features/month-row'
@@ -14,6 +15,7 @@ interface MonthlyListSectionProps {
 
 export function MonthlyListSection({ summaries, year }: MonthlyListSectionProps) {
   const router = useRouter()
+  const [isPending, startTransition] = useTransition()
   const currentMonth = parseMonth(new Date())
 
   if (summaries.length === 0) {
@@ -77,8 +79,9 @@ export function MonthlyListSection({ summaries, year }: MonthlyListSectionProps)
           {/* pill型セレクター */}
           <select
             value={year}
-            onChange={(e) => router.push(`/${e.target.value}`)}
-            className="rounded-lg border border-[#E5E7EB] px-3 py-1.5 text-sm font-medium bg-transparent appearance-none cursor-pointer"
+            onChange={(e) => startTransition(() => router.push(`/${e.target.value}`))}
+            disabled={isPending}
+            className={`rounded-lg border border-[#E5E7EB] px-3 py-1.5 text-sm font-medium bg-transparent appearance-none cursor-pointer transition-opacity ${isPending ? 'opacity-50' : ''}`}
             aria-label="年を選択"
             style={{ backgroundImage: 'none' }}
           >

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-[color,background-color,border-color,box-shadow,opacity] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-[color,background-color,border-color,box-shadow,opacity,transform] active:scale-[0.97] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {

--- a/tests/e2e/household-flow.spec.ts
+++ b/tests/e2e/household-flow.spec.ts
@@ -44,23 +44,23 @@ test.describe('ログインページ', () => {
     ).toBeVisible()
   })
 
-  test('正しいパスワードで月一覧に遷移する', async ({ page }) => {
+  test('正しいパスワードで月詳細に遷移する', async ({ page }) => {
     await page.getByPlaceholder('パスワード').fill(MOCK_PASSWORD)
     await page.getByRole('button', { name: 'ログイン' }).click()
     await page.waitForURL(/\/\d{4}\/\d{2}/)
 
-    await expect(
-      page.getByText('※各月の収支は繰越に回す前の金額です')
-    ).toBeVisible()
+    await expect(page.getByText(/Balance/)).toBeVisible()
   })
 })
 
 // =============================================
-// 月一覧ページ（認証後のランディング）
+// 月一覧ページ（年別一覧）
 // =============================================
 test.describe('月一覧ページ', () => {
   test.beforeEach(async ({ page }) => {
     await login(page)
+    await page.goto('/2026')
+    await page.waitForURL(/\/2026$/)
   })
 
   test('月一覧の注記が表示される', async ({ page }) => {
@@ -497,9 +497,7 @@ test.describe('テーマ切り替え', () => {
   test('テーマ切り替えボタンが存在する', async ({ page }) => {
     await login(page)
 
-    const themeButton = page.locator('header button').filter({
-      has: page.locator('svg.lucide-sun, svg.lucide-moon'),
-    })
+    const themeButton = page.getByRole('button', { name: 'テーマを切り替え' })
     await expect(themeButton).toBeVisible()
   })
 })


### PR DESCRIPTION
## Summary
- 全Buttonコンポーネントに `active:scale-[0.97]` を追加し、タップ時の即時フィードバックを実現
- MonthSelectorの月切り替え・MonthlyListSectionの年セレクターに `useTransition` を導入し、遷移中のローディング状態（半透明+操作無効）を表示
- MonthRowの行タップに `active:scale-[0.99]` + `active:bg-muted/50` を追加

## Test plan
- [x] `npm run build` ビルド成功
- [x] `npm run test:run` 全240テストパス
- [x] ブラウザで月切り替え・月一覧行タップ・年セレクター切り替えの動作確認済み
- [ ] モバイル実機でのタップフィードバック体感確認