### PR TITLE
feat: パスキー（WebAuthn）認証を追加

### DIFF
--- a/.env.mock
+++ b/.env.mock
@@ -10,3 +10,8 @@ SUPABASE_SERVICE_ROLE_KEY=mock-service-role-key
 
 # 認証用パスワードハッシュ（パスワード: "password"）
 APP_PASSWORD_HASH_BASE64=JDJiJDEwJFc1dHFKYVlHWWpLQkdVTTZ1aDF3N09Ed3pRelNvVE1jUEVDVHBEajNQdGFNT09RTmNhNTBt
+
+# WebAuthn
+WEBAUTHN_RP_ID=localhost
+WEBAUTHN_RP_ORIGIN=http://localhost:3000
+WEBAUTHN_RP_NAME=家計計算アプリ

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ yarn-error.log*
 # vercel
 .vercel
 
+# supabase
+supabase/.temp/
+
 # typescript
 *.tsbuildinfo
 next-env.d.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slot": "^1.2.4",
+        "@simplewebauthn/browser": "^13.3.0",
+        "@simplewebauthn/server": "^13.3.0",
         "@supabase/supabase-js": "^2.93.3",
         "@vercel/speed-insights": "^1.3.1",
         "bcryptjs": "^3.0.3",
@@ -1247,6 +1249,12 @@
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
     },
+    "node_modules/@hexagon/base64": {
+      "version": "1.1.28",
+      "resolved": "https://registry.npmjs.org/@hexagon/base64/-/base64-1.1.28.tgz",
+      "integrity": "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==",
+      "license": "MIT"
+    },
     "node_modules/@hookform/resolvers": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
@@ -1915,6 +1923,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@levischuck/tiny-cbor": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@levischuck/tiny-cbor/-/tiny-cbor-0.2.11.tgz",
+      "integrity": "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==",
+      "license": "MIT"
+    },
     "node_modules/@lottiefiles/dotlottie-react": {
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/@lottiefiles/dotlottie-react/-/dotlottie-react-0.19.0.tgz",
@@ -2180,6 +2194,174 @@
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@peculiar/asn1-android": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-android/-/asn1-android-2.7.0.tgz",
+      "integrity": "sha512-iD3VskhVQnM4nE3PN9cBdPTR7JrqZy3FYk+uD2CeG6DUqKoANqaEfx0f7izPmW+Qm5JBM35ek+viLCmjy18ByQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-cms": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.7.0.tgz",
+      "integrity": "sha512-hew63shtzzvBcSHbhm+cyAmKe6AIfinT9hzEqSPjDC6opTTMKmTkQ0gHuN2KsWlvqiKw1S/fS94fhag/FJkioQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "@peculiar/asn1-x509-attr": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-csr": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.7.0.tgz",
+      "integrity": "sha512-VVsAyGqErT9D1SY4aEqozThXMVI+ssVRiv2DDeYuvpBKLIgZ3hYs3Ay3u/VSoKq6ESFi9cf6rf3IOOzfwh7oMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-ecc": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.7.0.tgz",
+      "integrity": "sha512-n7KEs/Q/wrB415cxy4fHOBhegp4NdJ15fkJPwcB/3/8iNBQC2L/N7SChJPKDJPZGYH0jD4Tg4/0vnHmwghnbKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pfx": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.7.0.tgz",
+      "integrity": "sha512-V/nrlQVmhg7lYAsM7E13UDL5erAwFv6kCIVFqNaMIHSVi7dngcT839JkRTkQBqznMG98l2XjxYk74ZztAohZzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.7.0",
+        "@peculiar/asn1-pkcs8": "^2.7.0",
+        "@peculiar/asn1-rsa": "^2.7.0",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs8": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.7.0.tgz",
+      "integrity": "sha512-9GTl1nE8Mx1kTZ+7QyYatDyKsm34QcWRBFkY1iPvWC3X4Dona5s/tlLiQsx5WzVdZqiMBZNYT0buyw4/vbhnjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs9": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.7.0.tgz",
+      "integrity": "sha512-Bh7m+OuIaSEllPQcSd9OSp93F4ROWH7sbITWV8MI+8dwsjE5111/87VxiWVvYFKyww3vp39geLv9ENqhwWHcew==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.7.0",
+        "@peculiar/asn1-pfx": "^2.7.0",
+        "@peculiar/asn1-pkcs8": "^2.7.0",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "@peculiar/asn1-x509-attr": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-rsa": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.7.0.tgz",
+      "integrity": "sha512-/qvENQrXyTZURjMqSeofHul0JJt2sNSzSwk36pl2olkHbaioMQgrASDZAlHXl0xUlnVbHj0uGgOrBMTb5x2aJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.7.0.tgz",
+      "integrity": "sha512-W8ZfWzLmQnrcky+eh3tni4IozMdqBDiHWU0N+vve/UGjMaUs8c0L7A2oEdkBXS8rTpWDpK/aoI3DG/L/hxmxPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.7.0.tgz",
+      "integrity": "sha512-mUn9RRrkGDnG4ALfunDmzyRW5dg+sWCj/pfnCCqEHYbkGxEpvUt6iVJv8Yw1cyp6SWZ26ZE5oSmI5SqEaen15g==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509-attr": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.7.0.tgz",
+      "integrity": "sha512-NS8e7SOgXipkzUPLF/sce7ukpMpWjhxYsH0n6Y+bHYo4TTxOb95Zv7hqwSuL212mj5YxovjdOKQOgH1As3E94w==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+      "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/x509": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.3.tgz",
+      "integrity": "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.0",
+        "@peculiar/asn1-csr": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.0",
+        "@peculiar/asn1-pkcs9": "^2.6.0",
+        "@peculiar/asn1-rsa": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "pvtsutils": "^1.3.6",
+        "reflect-metadata": "^0.2.2",
+        "tslib": "^2.8.1",
+        "tsyringe": "^4.10.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/@playwright/test": {
       "version": "1.58.1",
@@ -4249,6 +4431,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@simplewebauthn/browser": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/browser/-/browser-13.3.0.tgz",
+      "integrity": "sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ==",
+      "license": "MIT"
+    },
+    "node_modules/@simplewebauthn/server": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/server/-/server-13.3.0.tgz",
+      "integrity": "sha512-MLHYFrYG8/wK2i+86XMhiecK72nMaHKKt4bo+7Q1TbuG9iGjlSdfkPWKO5ZFE/BX+ygCJ7pr8H/AJeyAj1EaTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hexagon/base64": "^1.1.27",
+        "@levischuck/tiny-cbor": "^0.2.2",
+        "@peculiar/asn1-android": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.1",
+        "@peculiar/asn1-rsa": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/x509": "^1.14.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -5882,6 +6089,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/asn1js": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+      "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.5",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/assertion-error": {
@@ -9836,6 +10057,24 @@
         "node": ">=6"
       }
     },
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -10111,6 +10350,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0"
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -11146,6 +11391,24 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tsyringe": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+      "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/tsyringe/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
     },
     "node_modules/tw-animate-css": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",
+    "@simplewebauthn/browser": "^13.3.0",
+    "@simplewebauthn/server": "^13.3.0",
     "@supabase/supabase-js": "^2.93.3",
     "@vercel/speed-insights": "^1.3.1",
     "bcryptjs": "^3.0.3",

--- a/src/app/actions/auth.ts
+++ b/src/app/actions/auth.ts
@@ -1,16 +1,13 @@
 'use server'
 
-import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
 import bcrypt from 'bcryptjs'
 import { createClient } from '@/lib/supabase/server'
-
-const SESSION_COOKIE_NAME = 'household_session'
-const SESSION_MAX_AGE = 60 * 60 * 24 * 7 // 7日間
-
-function generateSessionToken(): string {
-  return crypto.randomUUID()
-}
+import {
+  createSession,
+  deleteSession,
+  isAuthenticated as checkSession,
+} from '@/lib/webauthn/session'
 
 export async function login(
   _prevState: { error?: string },
@@ -22,14 +19,12 @@ export async function login(
     return { error: 'パスワードを入力してください' }
   }
 
-  // 環境変数からハッシュを取得（Base64デコードが必要）
   const hashBase64 = process.env.APP_PASSWORD_HASH_BASE64
   const storedHash = hashBase64
     ? Buffer.from(hashBase64, 'base64').toString('utf-8')
     : null
 
   if (!storedHash) {
-    // Supabaseからハッシュを取得を試みる
     const supabase = await createClient()
     const { data } = await supabase
       .from('app_settings')
@@ -52,27 +47,15 @@ export async function login(
     }
   }
 
-  // セッションCookie設定
-  const cookieStore = await cookies()
-  cookieStore.set(SESSION_COOKIE_NAME, generateSessionToken(), {
-    httpOnly: true,
-    secure: process.env.NODE_ENV === 'production',
-    sameSite: 'lax',
-    maxAge: SESSION_MAX_AGE,
-    path: '/',
-  })
-
+  await createSession(null, 'password')
   redirect('/')
 }
 
 export async function logout(): Promise<void> {
-  const cookieStore = await cookies()
-  cookieStore.delete(SESSION_COOKIE_NAME)
+  await deleteSession()
   redirect('/login')
 }
 
 export async function isAuthenticated(): Promise<boolean> {
-  const cookieStore = await cookies()
-  const session = cookieStore.get(SESSION_COOKIE_NAME)
-  return !!session
+  return checkSession()
 }

--- a/src/app/actions/passkeys.ts
+++ b/src/app/actions/passkeys.ts
@@ -1,0 +1,304 @@
+'use server'
+
+import {
+  generateRegistrationOptions as generateRegOptions,
+  verifyRegistrationResponse,
+  generateAuthenticationOptions as generateAuthOptions,
+  verifyAuthenticationResponse,
+} from '@simplewebauthn/server'
+import type {
+  RegistrationResponseJSON,
+  AuthenticationResponseJSON,
+  AuthenticatorTransportFuture,
+} from '@simplewebauthn/server'
+import { createClient } from '@/lib/supabase/server'
+import { getWebAuthnConfig } from '@/lib/webauthn/config'
+import { createSession, isAuthenticated } from '@/lib/webauthn/session'
+import type { ActionResult, Person } from '@/types'
+
+const CHALLENGE_TTL_MINUTES = 5
+
+export interface PasskeyInfo {
+  id: string
+  person: Person
+  deviceName: string | null
+  createdAt: string
+}
+
+// --- 登録 ---
+
+export async function generateRegistrationOptions(
+  person: Person
+): Promise<ActionResult<PublicKeyCredentialCreationOptionsJSON>> {
+  if (!(await isAuthenticated())) {
+    return { success: false, error: '認証が必要です' }
+  }
+
+  const config = getWebAuthnConfig()
+  const supabase = await createClient()
+
+  // 既存のパスキーを取得（同一personの重複登録防止のため excludeCredentials に含める）
+  const { data: existingCredentials } = await supabase
+    .from('passkey_credentials')
+    .select('id, transports')
+    .eq('person', person)
+
+  const userID = new TextEncoder().encode(person)
+
+  const options = await generateRegOptions({
+    rpName: config.rpName,
+    rpID: config.rpID,
+    userName: person === 'husband' ? '夫' : '妻',
+    userDisplayName: person === 'husband' ? '夫' : '妻',
+    userID,
+    attestationType: 'none',
+    excludeCredentials: (existingCredentials ?? []).map((cred) => ({
+      id: cred.id,
+      transports: (cred.transports ?? []) as AuthenticatorTransportFuture[],
+    })),
+    authenticatorSelection: {
+      residentKey: 'required',
+      userVerification: 'preferred',
+    },
+  })
+
+  // チャレンジをDBに保存
+  await supabase.from('webauthn_challenges').insert({
+    challenge: options.challenge,
+    type: 'registration',
+    person,
+    expires_at: new Date(
+      Date.now() + CHALLENGE_TTL_MINUTES * 60 * 1000
+    ).toISOString(),
+  })
+
+  // 期限切れチャレンジを掃除
+  await supabase
+    .from('webauthn_challenges')
+    .delete()
+    .lt('expires_at', new Date().toISOString())
+
+  return { success: true, data: options }
+}
+
+export async function verifyRegistration(
+  person: Person,
+  credential: RegistrationResponseJSON,
+  deviceName?: string
+): Promise<ActionResult<{ credentialId: string }>> {
+  if (!(await isAuthenticated())) {
+    return { success: false, error: '認証が必要です' }
+  }
+
+  const config = getWebAuthnConfig()
+  const supabase = await createClient()
+
+  // チャレンジを取得
+  const { data: challengeRecord } = await supabase
+    .from('webauthn_challenges')
+    .select('challenge, expires_at')
+    .eq('type', 'registration')
+    .eq('person', person)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .single()
+
+  if (!challengeRecord) {
+    return { success: false, error: 'チャレンジが見つかりません。もう一度お試しください' }
+  }
+
+  if (new Date(challengeRecord.expires_at) < new Date()) {
+    return { success: false, error: 'チャレンジの有効期限が切れました。もう一度お試しください' }
+  }
+
+  const verification = await verifyRegistrationResponse({
+    response: credential,
+    expectedChallenge: challengeRecord.challenge,
+    expectedOrigin: config.origin,
+    expectedRPID: config.rpID,
+    requireUserVerification: false,
+  })
+
+  if (!verification.verified || !verification.registrationInfo) {
+    return { success: false, error: 'パスキーの検証に失敗しました' }
+  }
+
+  const { credential: registeredCredential, credentialBackedUp } =
+    verification.registrationInfo
+
+  // 資格情報を保存
+  const { error } = await supabase.from('passkey_credentials').insert({
+    id: registeredCredential.id,
+    person,
+    public_key: Buffer.from(registeredCredential.publicKey).toString('base64'),
+    counter: registeredCredential.counter,
+    device_name: deviceName ?? (credentialBackedUp ? 'クラウド同期' : 'デバイス'),
+    transports: credential.response.transports ?? [],
+  })
+
+  if (error) {
+    return { success: false, error: `パスキーの保存に失敗しました: ${error.message}` }
+  }
+
+  // 使用済みチャレンジを削除
+  await supabase
+    .from('webauthn_challenges')
+    .delete()
+    .eq('type', 'registration')
+    .eq('person', person)
+
+  return { success: true, data: { credentialId: registeredCredential.id } }
+}
+
+// --- 認証 ---
+
+export async function generateAuthenticationOptions(): Promise<
+  ActionResult<PublicKeyCredentialRequestOptionsJSON>
+> {
+  const config = getWebAuthnConfig()
+  const supabase = await createClient()
+
+  const options = await generateAuthOptions({
+    rpID: config.rpID,
+    userVerification: 'preferred',
+    // allowCredentials を空にして discoverable credentials を使う
+  })
+
+  await supabase.from('webauthn_challenges').insert({
+    challenge: options.challenge,
+    type: 'authentication',
+    person: null,
+    expires_at: new Date(
+      Date.now() + CHALLENGE_TTL_MINUTES * 60 * 1000
+    ).toISOString(),
+  })
+
+  // 期限切れチャレンジを掃除
+  await supabase
+    .from('webauthn_challenges')
+    .delete()
+    .lt('expires_at', new Date().toISOString())
+
+  return { success: true, data: options }
+}
+
+export async function verifyAuthentication(
+  credential: AuthenticationResponseJSON
+): Promise<ActionResult<{ person: Person }>> {
+  const config = getWebAuthnConfig()
+  const supabase = await createClient()
+
+  // 資格情報をIDで検索
+  const { data: storedCredential } = await supabase
+    .from('passkey_credentials')
+    .select('id, person, public_key, counter, transports')
+    .eq('id', credential.id)
+    .single()
+
+  if (!storedCredential) {
+    return { success: false, error: '登録されていないパスキーです' }
+  }
+
+  // 最新のチャレンジを取得
+  const { data: challengeRecord } = await supabase
+    .from('webauthn_challenges')
+    .select('challenge, expires_at')
+    .eq('type', 'authentication')
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .single()
+
+  if (!challengeRecord) {
+    return { success: false, error: 'チャレンジが見つかりません。もう一度お試しください' }
+  }
+
+  if (new Date(challengeRecord.expires_at) < new Date()) {
+    return { success: false, error: 'チャレンジの有効期限が切れました。もう一度お試しください' }
+  }
+
+  const publicKeyBytes = Buffer.from(storedCredential.public_key, 'base64')
+
+  const verification = await verifyAuthenticationResponse({
+    response: credential,
+    expectedChallenge: challengeRecord.challenge,
+    expectedOrigin: config.origin,
+    expectedRPID: config.rpID,
+    requireUserVerification: false,
+    credential: {
+      id: storedCredential.id,
+      publicKey: new Uint8Array(publicKeyBytes),
+      counter: storedCredential.counter,
+      transports: (storedCredential.transports ?? []) as AuthenticatorTransportFuture[],
+    },
+  })
+
+  if (!verification.verified) {
+    return { success: false, error: 'パスキーの認証に失敗しました' }
+  }
+
+  // カウンターを更新
+  await supabase
+    .from('passkey_credentials')
+    .update({ counter: verification.authenticationInfo.newCounter })
+    .eq('id', storedCredential.id)
+
+  // 使用済みチャレンジを削除
+  await supabase
+    .from('webauthn_challenges')
+    .delete()
+    .eq('type', 'authentication')
+
+  const person = storedCredential.person as Person
+
+  // セッション作成
+  await createSession(person, 'passkey')
+
+  return { success: true, data: { person } }
+}
+
+// --- 管理 ---
+
+export async function listPasskeys(): Promise<ActionResult<PasskeyInfo[]>> {
+  if (!(await isAuthenticated())) {
+    return { success: false, error: '認証が必要です' }
+  }
+
+  const supabase = await createClient()
+  const { data, error } = await supabase
+    .from('passkey_credentials')
+    .select('id, person, device_name, created_at')
+    .order('created_at', { ascending: true })
+
+  if (error) {
+    return { success: false, error: `パスキー一覧の取得に失敗しました: ${error.message}` }
+  }
+
+  const passkeys: PasskeyInfo[] = (data ?? []).map((row) => ({
+    id: row.id,
+    person: row.person as Person,
+    deviceName: row.device_name,
+    createdAt: row.created_at,
+  }))
+
+  return { success: true, data: passkeys }
+}
+
+export async function deletePasskey(
+  credentialId: string
+): Promise<ActionResult> {
+  if (!(await isAuthenticated())) {
+    return { success: false, error: '認証が必要です' }
+  }
+
+  const supabase = await createClient()
+  const { error } = await supabase
+    .from('passkey_credentials')
+    .delete()
+    .eq('id', credentialId)
+
+  if (error) {
+    return { success: false, error: `パスキーの削除に失敗しました: ${error.message}` }
+  }
+
+  return { success: true }
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { useActionState } from 'react'
 import { login } from '@/app/actions/auth'
 import { ThemeToggle } from '@/components/ui/theme-toggle'
+import { PasskeyLoginButton } from '@/features/passkey/components/passkey-login-button'
 
 export default function LoginPage() {
   const [state, formAction, isPending] = useActionState(login, {})
@@ -88,6 +89,11 @@ export default function LoginPage() {
               {!isPending && <span className="text-lg font-normal">→</span>}
             </button>
           </form>
+
+          {/* パスキーログイン */}
+          <div className="mt-4">
+            <PasskeyLoginButton />
+          </div>
         </div>
       </main>
 

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,33 @@
+import Link from 'next/link'
+import { ArrowLeft } from 'lucide-react'
+import { PasskeySettings } from '@/features/passkey'
+import { HeaderActions } from '@/components/layout/header-actions'
+
+export default function SettingsPage() {
+  return (
+    <div className="min-h-screen bg-background flex flex-col">
+      <header className="flex items-center justify-between px-5 py-3.5 border-b border-border">
+        <div className="flex items-center gap-2">
+          <Link
+            href="/"
+            className="text-sub-text hover:text-accent transition-colors"
+            aria-label="戻る"
+          >
+            <ArrowLeft className="h-4 w-4" />
+          </Link>
+          <span className="text-[11px] font-bold tracking-[0.18em] uppercase text-sub-text">
+            設定
+          </span>
+        </div>
+        <HeaderActions />
+      </header>
+
+      <main id="main" tabIndex={-1} className="flex-1 px-5 pt-6 pb-8 max-w-md mx-auto w-full">
+        <h1 className="text-[18px] font-bold tracking-[-0.02em] mb-6">
+          パスキー管理
+        </h1>
+        <PasskeySettings />
+      </main>
+    </div>
+  )
+}

--- a/src/components/layout/header-actions.tsx
+++ b/src/components/layout/header-actions.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { LogOut } from 'lucide-react'
+import Link from 'next/link'
+import { LogOut, Settings } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { ThemeToggle } from '@/components/ui/theme-toggle'
 import { logout } from '@/app/actions/auth'
@@ -17,6 +18,17 @@ export function HeaderActions({ variant = 'default' }: HeaderActionsProps) {
   return (
     <div className="flex items-center gap-1">
       <ThemeToggle className={iconClass} />
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        className={iconClass}
+        asChild
+        aria-label="設定"
+      >
+        <Link href="/settings">
+          <Settings className="h-4 w-4" />
+        </Link>
+      </Button>
       <form action={logout}>
         <Button
           variant="ghost"

--- a/src/features/passkey/components/passkey-list.tsx
+++ b/src/features/passkey/components/passkey-list.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+import { useState } from 'react'
+import { Trash2, Key } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { deletePasskey } from '@/app/actions/passkeys'
+import type { PasskeyInfo } from '../types'
+
+interface PasskeyListProps {
+  passkeys: PasskeyInfo[]
+  onDeleted: () => void
+}
+
+export function PasskeyList({ passkeys, onDeleted }: PasskeyListProps) {
+  const [deletingId, setDeletingId] = useState<string | null>(null)
+
+  async function handleDelete(credentialId: string) {
+    setDeletingId(credentialId)
+    const result = await deletePasskey(credentialId)
+    setDeletingId(null)
+
+    if (result.success) {
+      onDeleted()
+    }
+  }
+
+  if (passkeys.length === 0) {
+    return (
+      <div className="text-center py-8 text-sub-text">
+        <Key className="h-8 w-8 mx-auto mb-2 opacity-40" />
+        <p className="text-[13px]">パスキーが登録されていません</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-2">
+      {passkeys.map((passkey) => (
+        <div
+          key={passkey.id}
+          className="flex items-center justify-between rounded-[12px] bg-muted/50 px-4 py-3"
+        >
+          <div className="flex items-center gap-3">
+            <Key className="h-4 w-4 text-sub-text" />
+            <div>
+              <p className="text-[13px] font-semibold">
+                {passkey.deviceName ?? 'パスキー'}
+              </p>
+              <p className="text-[11px] text-sub-text">
+                {passkey.person === 'husband' ? '夫' : '妻'} ・{' '}
+                {new Date(passkey.createdAt).toLocaleDateString('ja-JP')}
+              </p>
+            </div>
+          </div>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={() => handleDelete(passkey.id)}
+            disabled={deletingId === passkey.id}
+            aria-label={`${passkey.deviceName ?? 'パスキー'}を削除`}
+          >
+            <Trash2 className="h-4 w-4 text-destructive" />
+          </Button>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/features/passkey/components/passkey-login-button.tsx
+++ b/src/features/passkey/components/passkey-login-button.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { useState } from 'react'
+import {
+  startAuthentication,
+  type PublicKeyCredentialRequestOptionsJSON,
+} from '@simplewebauthn/browser'
+import { Key } from 'lucide-react'
+import {
+  generateAuthenticationOptions,
+  verifyAuthentication,
+} from '@/app/actions/passkeys'
+
+export function PasskeyLoginButton() {
+  const [isAuthenticating, setIsAuthenticating] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handlePasskeyLogin() {
+    setIsAuthenticating(true)
+    setError(null)
+
+    try {
+      const optionsResult = await generateAuthenticationOptions()
+      if (!optionsResult.success || !optionsResult.data) {
+        setError(optionsResult.error ?? '認証オプションの取得に失敗しました')
+        return
+      }
+
+      const credential = await startAuthentication({
+        optionsJSON: optionsResult.data as unknown as PublicKeyCredentialRequestOptionsJSON,
+      })
+
+      const verifyResult = await verifyAuthentication(credential)
+      if (!verifyResult.success) {
+        setError(verifyResult.error ?? '認証に失敗しました')
+        return
+      }
+
+      window.location.href = '/'
+    } catch (err) {
+      if (err instanceof Error && err.name === 'NotAllowedError') {
+        setError('パスキー認証がキャンセルされました')
+      } else {
+        setError('パスキー認証中にエラーが発生しました')
+      }
+    } finally {
+      setIsAuthenticating(false)
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-3">
+        <div className="flex-1 h-px bg-border" />
+        <span className="text-[11px] text-sub-text">また��</span>
+        <div className="flex-1 h-px bg-border" />
+      </div>
+
+      <button
+        type="button"
+        onClick={handlePasskeyLogin}
+        disabled={isAuthenticating}
+        className="w-full h-12 px-5 bg-foreground text-background rounded-[12px] text-[13px] font-bold tracking-[0.10em] flex items-center justify-center gap-2 disabled:opacity-50 transition-opacity"
+      >
+        <Key className="h-4 w-4" />
+        {isAuthenticating ? '認証中…' : 'パスキーでログイン'}
+      </button>
+
+      {error && (
+        <div className="flex items-center gap-2">
+          <span className="w-1.5 h-1.5 rounded-full bg-destructive shrink-0" />
+          <span className="text-[12px] font-semibold text-destructive">{error}</span>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/features/passkey/components/passkey-login-button.tsx
+++ b/src/features/passkey/components/passkey-login-button.tsx
@@ -52,7 +52,7 @@ export function PasskeyLoginButton() {
     <div className="space-y-3">
       <div className="flex items-center gap-3">
         <div className="flex-1 h-px bg-border" />
-        <span className="text-[11px] text-sub-text">また��</span>
+        <span className="text-[11px] text-sub-text">または</span>
         <div className="flex-1 h-px bg-border" />
       </div>
 

--- a/src/features/passkey/components/register-passkey-form.tsx
+++ b/src/features/passkey/components/register-passkey-form.tsx
@@ -1,0 +1,133 @@
+'use client'
+
+import { useState } from 'react'
+import {
+  startRegistration,
+  type PublicKeyCredentialCreationOptionsJSON,
+} from '@simplewebauthn/browser'
+import { Plus } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  generateRegistrationOptions,
+  verifyRegistration,
+} from '@/app/actions/passkeys'
+import type { Person } from '@/types'
+
+interface RegisterPasskeyFormProps {
+  onRegistered: () => void
+}
+
+export function RegisterPasskeyForm({ onRegistered }: RegisterPasskeyFormProps) {
+  const [person, setPerson] = useState<Person>('husband')
+  const [deviceName, setDeviceName] = useState('')
+  const [isRegistering, setIsRegistering] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleRegister() {
+    setIsRegistering(true)
+    setError(null)
+
+    try {
+      const optionsResult = await generateRegistrationOptions(person)
+      if (!optionsResult.success || !optionsResult.data) {
+        setError(optionsResult.error ?? '登録オプションの取得に失敗しました')
+        return
+      }
+
+      const credential = await startRegistration({
+        optionsJSON: optionsResult.data as unknown as PublicKeyCredentialCreationOptionsJSON,
+      })
+
+      const verifyResult = await verifyRegistration(
+        person,
+        credential,
+        deviceName || undefined
+      )
+
+      if (!verifyResult.success) {
+        setError(verifyResult.error ?? '登録の検証に失敗しました')
+        return
+      }
+
+      setDeviceName('')
+      onRegistered()
+    } catch (err) {
+      if (err instanceof Error && err.name === 'NotAllowedError') {
+        setError('パスキーの登録がキャンセルされました')
+      } else {
+        setError('パスキーの登録中にエラーが発生しました')
+      }
+    } finally {
+      setIsRegistering(false)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Person 選択 */}
+      <div>
+        <label className="text-[11px] font-bold tracking-[0.14em] uppercase text-sub-text block mb-2">
+          登録する人
+        </label>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => setPerson('husband')}
+            className={`flex-1 h-10 rounded-[10px] text-[13px] font-semibold transition-colors ${
+              person === 'husband'
+                ? 'bg-[#2563EB] text-white'
+                : 'bg-muted text-muted-foreground'
+            }`}
+          >
+            夫
+          </button>
+          <button
+            type="button"
+            onClick={() => setPerson('wife')}
+            className={`flex-1 h-10 rounded-[10px] text-[13px] font-semibold transition-colors ${
+              person === 'wife'
+                ? 'bg-[#2563EB] text-white'
+                : 'bg-muted text-muted-foreground'
+            }`}
+          >
+            妻
+          </button>
+        </div>
+      </div>
+
+      {/* デバイス名 */}
+      <div>
+        <label
+          htmlFor="device-name"
+          className="text-[11px] font-bold tracking-[0.14em] uppercase text-sub-text block mb-2"
+        >
+          デバイス名（任意）
+        </label>
+        <input
+          id="device-name"
+          type="text"
+          value={deviceName}
+          onChange={(e) => setDeviceName(e.target.value)}
+          placeholder="例: iPhone, 1Password"
+          className="w-full h-10 rounded-[10px] bg-muted px-3 text-[13px] border-none outline-none placeholder:text-muted-foreground/50"
+        />
+      </div>
+
+      {error && (
+        <div className="flex items-center gap-2">
+          <span className="w-1.5 h-1.5 rounded-full bg-destructive shrink-0" />
+          <span className="text-[12px] font-semibold text-destructive">{error}</span>
+        </div>
+      )}
+
+      <Button
+        onClick={handleRegister}
+        disabled={isRegistering}
+        className="w-full h-11 rounded-[12px] bg-[#2563EB] text-white text-[13px] font-bold tracking-[0.10em]"
+      >
+        <Plus className="h-4 w-4 mr-1.5" />
+        {isRegistering ? '登録中…' : 'パスキーを登録'}
+      </Button>
+    </div>
+  )
+}

--- a/src/features/passkey/index.tsx
+++ b/src/features/passkey/index.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import { useCallback, useEffect, useState, useTransition } from 'react'
+import { listPasskeys } from '@/app/actions/passkeys'
+import { PasskeyList } from './components/passkey-list'
+import { RegisterPasskeyForm } from './components/register-passkey-form'
+import type { PasskeyInfo } from './types'
+
+export function PasskeySettings() {
+  const [passkeys, setPasskeys] = useState<PasskeyInfo[]>([])
+  const [isPending, startTransition] = useTransition()
+
+  const fetchPasskeys = useCallback(() => {
+    startTransition(async () => {
+      const result = await listPasskeys()
+      if (result.success && result.data) {
+        setPasskeys(result.data)
+      }
+    })
+  }, [])
+
+  useEffect(() => {
+    fetchPasskeys()
+  }, [fetchPasskeys])
+
+  return (
+    <div className="space-y-6">
+      {/* 登録済みパスキー一覧 */}
+      <section>
+        <h2 className="text-[11px] font-bold tracking-[0.14em] uppercase text-sub-text mb-3">
+          登録済みパスキー
+        </h2>
+        {isPending ? (
+          <div className="text-center py-6 text-[13px] text-sub-text">
+            読み込み中…
+          </div>
+        ) : (
+          <PasskeyList passkeys={passkeys} onDeleted={fetchPasskeys} />
+        )}
+      </section>
+
+      {/* 登録フォーム */}
+      <section className="border-t border-border pt-6">
+        <h2 className="text-[11px] font-bold tracking-[0.14em] uppercase text-sub-text mb-3">
+          新しいパスキーを登録
+        </h2>
+        <RegisterPasskeyForm onRegistered={fetchPasskeys} />
+      </section>
+    </div>
+  )
+}

--- a/src/features/passkey/types.ts
+++ b/src/features/passkey/types.ts
@@ -1,0 +1,8 @@
+import type { Person } from '@/types'
+
+export interface PasskeyInfo {
+  id: string
+  person: Person
+  deviceName: string | null
+  createdAt: string
+}

--- a/src/lib/webauthn/config.ts
+++ b/src/lib/webauthn/config.ts
@@ -1,0 +1,14 @@
+export function getWebAuthnConfig() {
+  const rpID = process.env.WEBAUTHN_RP_ID
+  const origin = process.env.WEBAUTHN_RP_ORIGIN
+
+  if (!rpID || !origin) {
+    throw new Error('WEBAUTHN_RP_ID と WEBAUTHN_RP_ORIGIN の環境変数が必要です')
+  }
+
+  return {
+    rpID,
+    rpName: process.env.WEBAUTHN_RP_NAME ?? '家計計算アプリ',
+    origin,
+  }
+}

--- a/src/lib/webauthn/session.ts
+++ b/src/lib/webauthn/session.ts
@@ -1,0 +1,117 @@
+import { cookies } from 'next/headers'
+import { createClient } from '@/lib/supabase/server'
+import type { Person } from '@/types'
+
+const SESSION_COOKIE_NAME = 'household_session'
+const SESSION_MAX_AGE = 60 * 60 * 24 * 7 // 7日間
+
+function generateToken(): string {
+  const bytes = new Uint8Array(32)
+  crypto.getRandomValues(bytes)
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')
+}
+
+export async function createSession(
+  person: Person | null,
+  authMethod: 'password' | 'passkey'
+): Promise<string> {
+  const token = generateToken()
+  const expiresAt = new Date(Date.now() + SESSION_MAX_AGE * 1000)
+
+  const supabase = await createClient()
+  const { error } = await supabase.from('sessions').insert({
+    token,
+    person,
+    auth_method: authMethod,
+    expires_at: expiresAt.toISOString(),
+  })
+
+  if (error) {
+    throw new Error(`セッション作成に失敗しました: ${error.message}`)
+  }
+
+  const cookieStore = await cookies()
+  cookieStore.set(SESSION_COOKIE_NAME, token, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    maxAge: SESSION_MAX_AGE,
+    path: '/',
+  })
+
+  return token
+}
+
+export interface SessionInfo {
+  person: Person | null
+  authMethod: 'password' | 'passkey'
+}
+
+export async function getSession(): Promise<SessionInfo | null> {
+  const cookieStore = await cookies()
+  const cookie = cookieStore.get(SESSION_COOKIE_NAME)
+
+  if (!cookie?.value) {
+    return null
+  }
+
+  const supabase = await createClient()
+  const { data } = await supabase
+    .from('sessions')
+    .select('person, auth_method, expires_at')
+    .eq('token', cookie.value)
+    .single()
+
+  if (!data) {
+    return null
+  }
+
+  if (new Date(data.expires_at) < new Date()) {
+    await deleteSession()
+    return null
+  }
+
+  return {
+    person: data.person as Person | null,
+    authMethod: data.auth_method as 'password' | 'passkey',
+  }
+}
+
+export async function getSessionPerson(): Promise<Person | null> {
+  const session = await getSession()
+  return session?.person ?? null
+}
+
+export async function deleteSession(): Promise<void> {
+  const cookieStore = await cookies()
+  const cookie = cookieStore.get(SESSION_COOKIE_NAME)
+
+  if (cookie?.value) {
+    const supabase = await createClient()
+    await supabase.from('sessions').delete().eq('token', cookie.value)
+  }
+
+  cookieStore.delete(SESSION_COOKIE_NAME)
+}
+
+export async function isAuthenticated(): Promise<boolean> {
+  const cookieStore = await cookies()
+  const cookie = cookieStore.get(SESSION_COOKIE_NAME)
+
+  if (!cookie?.value) {
+    return false
+  }
+
+  const supabase = await createClient()
+  const { data } = await supabase
+    .from('sessions')
+    .select('expires_at')
+    .eq('token', cookie.value)
+    .single()
+
+  if (!data) {
+    return false
+  }
+
+  return new Date(data.expires_at) > new Date()
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,6 +8,12 @@ export interface ActionResult<T = unknown> {
 // 担当者
 export type Person = 'husband' | 'wife'
 
+// セッション
+export interface Session {
+  person: Person | null
+  authMethod: 'password' | 'passkey'
+}
+
 // 収入
 export interface Income {
   id: string

--- a/supabase/migrations/005_webauthn_passkeys.sql
+++ b/supabase/migrations/005_webauthn_passkeys.sql
@@ -1,0 +1,43 @@
+-- セッションテーブル（cookieにはtokenのみ保存、詳細はDBに）
+CREATE TABLE sessions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  token VARCHAR(64) UNIQUE NOT NULL,
+  person VARCHAR(10) CHECK (person IN ('husband', 'wife')),
+  auth_method VARCHAR(10) NOT NULL DEFAULT 'password'
+    CHECK (auth_method IN ('password', 'passkey')),
+  expires_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_sessions_token ON sessions(token);
+CREATE INDEX idx_sessions_expires_at ON sessions(expires_at);
+
+-- パスキー資格情報テー���ル
+CREATE TABLE passkey_credentials (
+  id TEXT PRIMARY KEY,
+  person VARCHAR(10) NOT NULL CHECK (person IN ('husband', 'wife')),
+  public_key BYTEA NOT NULL,
+  counter BIGINT NOT NULL DEFAULT 0,
+  device_name VARCHAR(100),
+  transports TEXT[],
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_passkey_credentials_person ON passkey_credentials(person);
+
+-- WebAuthn チャレンジ一時保存（5分で期限切れ）
+CREATE TABLE webauthn_challenges (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  challenge TEXT NOT NULL,
+  type VARCHAR(20) NOT NULL CHECK (type IN ('registration', 'authentication')),
+  person VARCHAR(10),
+  expires_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_webauthn_challenges_expires_at ON webauthn_challenges(expires_at);
+
+-- RLS有効化（service_roleはバイパスするためポリシー不要）
+ALTER TABLE sessions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE passkey_credentials ENABLE ROW LEVEL SECURITY;
+ALTER TABLE webauthn_challenges ENABLE ROW LEVEL SECURITY;

--- a/tests/e2e/household-flow.spec.ts
+++ b/tests/e2e/household-flow.spec.ts
@@ -5,7 +5,7 @@ const MOCK_PASSWORD = 'password'
 async function login(page: Page) {
   await page.goto('/login')
   await page.getByPlaceholder('パスワード').fill(MOCK_PASSWORD)
-  await page.getByRole('button', { name: 'ログイン' }).click()
+  await page.getByRole('button', { name: 'ログイン →' }).click()
   await page.waitForURL(/\/\d{4}\/\d{2}/)
 }
 
@@ -32,12 +32,12 @@ test.describe('ログインページ', () => {
   test('ログインフォームが表示される', async ({ page }) => {
     await expect(page.getByText('家計計算アプリ')).toBeVisible()
     await expect(page.getByPlaceholder('パスワード')).toBeVisible()
-    await expect(page.getByRole('button', { name: 'ログイン' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'ログイン →' })).toBeVisible()
   })
 
   test('不正なパスワードでエラーが表示される', async ({ page }) => {
     await page.getByPlaceholder('パスワード').fill('wrong-password')
-    await page.getByRole('button', { name: 'ログイン' }).click()
+    await page.getByRole('button', { name: 'ログイン →' }).click()
 
     await expect(
       page.getByText(/パスワードが正しくありません/)
@@ -46,7 +46,7 @@ test.describe('ログインページ', () => {
 
   test('正しいパスワードで月詳細に遷移する', async ({ page }) => {
     await page.getByPlaceholder('パスワード').fill(MOCK_PASSWORD)
-    await page.getByRole('button', { name: 'ログイン' }).click()
+    await page.getByRole('button', { name: 'ログイン →' }).click()
     await page.waitForURL(/\/\d{4}\/\d{2}/)
 
     await expect(page.getByText(/Balance/)).toBeVisible()

--- a/tests/e2e/reduced-motion.spec.ts
+++ b/tests/e2e/reduced-motion.spec.ts
@@ -5,7 +5,7 @@ const MOCK_PASSWORD = 'password'
 async function login(page: Page) {
   await page.goto('/login')
   await page.getByPlaceholder('パスワード').fill(MOCK_PASSWORD)
-  await page.getByRole('button', { name: 'ログイン' }).click()
+  await page.getByRole('button', { name: 'ログイン →' }).click()
   await page.waitForURL(/\/\d{4}\/\d{2}/)
 }
 

--- a/tests/integration/actions/auth.test.ts
+++ b/tests/integration/actions/auth.test.ts
@@ -3,21 +3,30 @@ import '../../../tests/mocks/next'
 import {
   mockSupabaseClient,
   mockSingleSuccess,
-  mockSingleError,
   clearSupabaseMocks,
 } from '../../../tests/mocks/supabase'
 import { mockCookies, mockRedirect } from '../../../tests/mocks/next'
 import { createFormData } from '../../../tests/mocks/helpers'
 
-// bcryptのモック
 vi.mock('bcryptjs', () => ({
   default: {
     compare: vi.fn(),
   },
 }))
 
+vi.mock('@/lib/webauthn/session', () => ({
+  createSession: vi.fn(async () => 'mock-session-token'),
+  deleteSession: vi.fn(async () => undefined),
+  isAuthenticated: vi.fn(async () => false),
+}))
+
 import bcrypt from 'bcryptjs'
 import { login, logout, isAuthenticated } from '@/app/actions/auth'
+import {
+  createSession,
+  deleteSession,
+  isAuthenticated as checkSession,
+} from '@/lib/webauthn/session'
 
 describe('auth actions', () => {
   beforeEach(() => {
@@ -28,12 +37,11 @@ describe('auth actions', () => {
     mockRedirect.mockClear()
     vi.clearAllMocks()
 
-    // 環境変数をクリア
     delete process.env.APP_PASSWORD_HASH_BASE64
   })
 
   describe('login', () => {
-    it('パスワード未入力でエラーを返す', async () => {
+    it('パスワード未入��でエラーを返す', async () => {
       const formData = createFormData({ password: '' })
 
       const result = await login({ error: undefined }, formData)
@@ -42,7 +50,6 @@ describe('auth actions', () => {
     })
 
     it('環境変数からハッシュを取得して認証成功', async () => {
-      // 環境変数にBase64エンコードされたハッシュを設定
       const mockHash = '$2a$10$testHashValue'
       process.env.APP_PASSWORD_HASH_BASE64 = Buffer.from(mockHash).toString(
         'base64'
@@ -52,13 +59,12 @@ describe('auth actions', () => {
 
       const formData = createFormData({ password: 'correct-password' })
 
-      // redirectは例外をスローするので、catchする
       await expect(login({ error: undefined }, formData)).rejects.toThrow(
         'NEXT_REDIRECT:/'
       )
 
       expect(bcrypt.compare).toHaveBeenCalledWith('correct-password', mockHash)
-      expect(mockCookies.set).toHaveBeenCalled()
+      expect(createSession).toHaveBeenCalledWith(null, 'password')
     })
 
     it('環境変数からハッシュを取得して認証失敗', async () => {
@@ -73,11 +79,10 @@ describe('auth actions', () => {
       const result = await login({ error: undefined }, formData)
 
       expect(result.error).toBe('パスワードが正しくありません')
-      expect(mockCookies.set).not.toHaveBeenCalled()
+      expect(createSession).not.toHaveBeenCalled()
     })
 
     it('Supabaseからハッシュを取得して認証成功', async () => {
-      // 環境変数なし
       mockSingleSuccess({ value: '$2a$10$supabaseHashValue' })
       vi.mocked(bcrypt.compare).mockResolvedValueOnce(true as never)
 
@@ -92,6 +97,7 @@ describe('auth actions', () => {
         'correct-password',
         '$2a$10$supabaseHashValue'
       )
+      expect(createSession).toHaveBeenCalledWith(null, 'password')
     })
 
     it('Supabaseからハッシュを取得して認証失敗', async () => {
@@ -105,7 +111,6 @@ describe('auth actions', () => {
     })
 
     it('認証設定がない場合エラーを返す', async () => {
-      // 環境変数なし、Supabaseもデータなし
       mockSingleSuccess(null)
 
       const formData = createFormData({ password: 'any-password' })
@@ -113,54 +118,28 @@ describe('auth actions', () => {
 
       expect(result.error).toBe('認証設定が見つかりません')
     })
-
-    it('認証成功時にセッションCookieが設定される', async () => {
-      const mockHash = '$2a$10$testHashValue'
-      process.env.APP_PASSWORD_HASH_BASE64 = Buffer.from(mockHash).toString(
-        'base64'
-      )
-      vi.mocked(bcrypt.compare).mockResolvedValueOnce(true as never)
-
-      const formData = createFormData({ password: 'correct-password' })
-
-      try {
-        await login({ error: undefined }, formData)
-      } catch {
-        // redirect例外を無視
-      }
-
-      expect(mockCookies.set).toHaveBeenCalledWith(
-        'household_session',
-        expect.any(String),
-        expect.objectContaining({
-          httpOnly: true,
-          sameSite: 'lax',
-          path: '/',
-        })
-      )
-    })
   })
 
   describe('logout', () => {
-    it('セッションCookieを削除してログインページにリダイレクト', async () => {
+    it('セッションを削除してログインページにリダイレクト', async () => {
       await expect(logout()).rejects.toThrow('NEXT_REDIRECT:/login')
 
-      expect(mockCookies.delete).toHaveBeenCalledWith('household_session')
+      expect(deleteSession).toHaveBeenCalled()
     })
   })
 
   describe('isAuthenticated', () => {
-    it('セッションCookieがあればtrueを返す', async () => {
-      mockCookies.get.mockReturnValueOnce({ value: 'session-token' })
+    it('セッションモジュールに委譲する', async () => {
+      vi.mocked(checkSession).mockResolvedValueOnce(true)
 
       const result = await isAuthenticated()
 
       expect(result).toBe(true)
-      expect(mockCookies.get).toHaveBeenCalledWith('household_session')
+      expect(checkSession).toHaveBeenCalled()
     })
 
-    it('セッションCookieがなければfalseを返す', async () => {
-      mockCookies.get.mockReturnValueOnce(undefined)
+    it('セッションがなければfalseを返す', async () => {
+      vi.mocked(checkSession).mockResolvedValueOnce(false)
 
       const result = await isAuthenticated()
 

--- a/tests/unit/lib/webauthn/config.test.ts
+++ b/tests/unit/lib/webauthn/config.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { getWebAuthnConfig } from '@/lib/webauthn/config'
+
+describe('getWebAuthnConfig', () => {
+  beforeEach(() => {
+    delete process.env.WEBAUTHN_RP_ID
+    delete process.env.WEBAUTHN_RP_ORIGIN
+    delete process.env.WEBAUTHN_RP_NAME
+  })
+
+  it('環境変数から設定を取得する', () => {
+    process.env.WEBAUTHN_RP_ID = 'example.com'
+    process.env.WEBAUTHN_RP_ORIGIN = 'https://example.com'
+    process.env.WEBAUTHN_RP_NAME = 'テストアプリ'
+
+    const config = getWebAuthnConfig()
+
+    expect(config).toEqual({
+      rpID: 'example.com',
+      rpName: 'テストアプリ',
+      origin: 'https://example.com',
+    })
+  })
+
+  it('RP_NAMEが未設定の場合デフォルト名を使用する', () => {
+    process.env.WEBAUTHN_RP_ID = 'localhost'
+    process.env.WEBAUTHN_RP_ORIGIN = 'http://localhost:3000'
+
+    const config = getWebAuthnConfig()
+
+    expect(config.rpName).toBe('家計計算アプリ')
+  })
+
+  it('RP_IDが未設定の場合エラーをスローする', () => {
+    process.env.WEBAUTHN_RP_ORIGIN = 'http://localhost:3000'
+
+    expect(() => getWebAuthnConfig()).toThrow(
+      'WEBAUTHN_RP_ID と WEBAUTHN_RP_ORIGIN の環境変数が必要です'
+    )
+  })
+
+  it('RP_ORIGINが未設定の場合エラーをスローする', () => {
+    process.env.WEBAUTHN_RP_ID = 'localhost'
+
+    expect(() => getWebAuthnConfig()).toThrow(
+      'WEBAUTHN_RP_ID と WEBAUTHN_RP_ORIGIN の環境変数が必要です'
+    )
+  })
+})

--- a/tests/unit/lib/webauthn/session.test.ts
+++ b/tests/unit/lib/webauthn/session.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import '../../../../tests/mocks/next'
+import {
+  mockSupabaseClient,
+  mockSingleSuccess,
+  clearSupabaseMocks,
+} from '../../../../tests/mocks/supabase'
+import { mockCookies } from '../../../../tests/mocks/next'
+
+import {
+  createSession,
+  getSession,
+  getSessionPerson,
+  deleteSession,
+  isAuthenticated,
+} from '@/lib/webauthn/session'
+
+describe('session module', () => {
+  beforeEach(() => {
+    clearSupabaseMocks()
+    mockCookies.get.mockClear()
+    mockCookies.set.mockClear()
+    mockCookies.delete.mockClear()
+  })
+
+  describe('createSession', () => {
+    it('セッションを作成してcookieを設定する', async () => {
+      // insert が成功を返すようにモック
+      mockSupabaseClient._queryBuilder.insert.mockResolvedValueOnce({
+        error: null,
+      })
+
+      const token = await createSession('husband', 'passkey')
+
+      expect(token).toHaveLength(64)
+      expect(mockSupabaseClient.from).toHaveBeenCalledWith('sessions')
+      expect(mockCookies.set).toHaveBeenCalledWith(
+        'household_session',
+        token,
+        expect.objectContaining({
+          httpOnly: true,
+          sameSite: 'lax',
+          path: '/',
+        })
+      )
+    })
+
+    it('person null（��スワードログイン）でもセッション作成できる', async () => {
+      mockSupabaseClient._queryBuilder.insert.mockResolvedValueOnce({
+        error: null,
+      })
+
+      const token = await createSession(null, 'password')
+
+      expect(token).toHaveLength(64)
+      expect(mockSupabaseClient.from).toHaveBeenCalledWith('sessions')
+    })
+
+    it('DB挿入失敗時にエラーをスローする', async () => {
+      mockSupabaseClient._queryBuilder.insert.mockResolvedValueOnce({
+        error: { message: 'DB error' },
+      })
+
+      await expect(createSession('wife', 'passkey')).rejects.toThrow(
+        'セッション作成に失敗しました'
+      )
+    })
+  })
+
+  describe('getSession', () => {
+    it('有効なセッションを返す', async () => {
+      mockCookies.get.mockReturnValueOnce({ value: 'valid-token' })
+
+      const futureDate = new Date(Date.now() + 86400000).toISOString()
+      mockSingleSuccess({
+        person: 'husband',
+        auth_method: 'passkey',
+        expires_at: futureDate,
+      })
+
+      const session = await getSession()
+
+      expect(session).toEqual({
+        person: 'husband',
+        authMethod: 'passkey',
+      })
+    })
+
+    it('cookieが��い場合nullを返す', async () => {
+      mockCookies.get.mockReturnValueOnce(undefined)
+
+      const session = await getSession()
+
+      expect(session).toBeNull()
+    })
+
+    it('DBにセッ���ョンがない場合nullを返す', async () => {
+      mockCookies.get.mockReturnValueOnce({ value: 'invalid-token' })
+      mockSingleSuccess(null)
+
+      const session = await getSession()
+
+      expect(session).toBeNull()
+    })
+
+    it('期限切れセッショ���の場合nullを返しセッションを削除する', async () => {
+      mockCookies.get.mockReturnValueOnce({ value: 'expired-token' })
+
+      const pastDate = new Date(Date.now() - 86400000).toISOString()
+      mockSingleSuccess({
+        person: 'wife',
+        auth_method: 'password',
+        expires_at: pastDate,
+      })
+
+      // deleteSession 内の cookie.get も必要
+      mockCookies.get.mockReturnValueOnce({ value: 'expired-token' })
+
+      const session = await getSession()
+
+      expect(session).toBeNull()
+      expect(mockCookies.delete).toHaveBeenCalledWith('household_session')
+    })
+  })
+
+  describe('getSessionPerson', () => {
+    it('セッションからpersonを返す', async () => {
+      mockCookies.get.mockReturnValueOnce({ value: 'token' })
+
+      const futureDate = new Date(Date.now() + 86400000).toISOString()
+      mockSingleSuccess({
+        person: 'wife',
+        auth_method: 'passkey',
+        expires_at: futureDate,
+      })
+
+      const person = await getSessionPerson()
+
+      expect(person).toBe('wife')
+    })
+
+    it('セッションがない場合nullを返す', async () => {
+      mockCookies.get.mockReturnValueOnce(undefined)
+
+      const person = await getSessionPerson()
+
+      expect(person).toBeNull()
+    })
+  })
+
+  describe('deleteSession', () => {
+    it('DBからセッションを削除しcookieを削除する', async () => {
+      mockCookies.get.mockReturnValueOnce({ value: 'session-token' })
+
+      await deleteSession()
+
+      expect(mockSupabaseClient.from).toHaveBeenCalledWith('sessions')
+      expect(mockCookies.delete).toHaveBeenCalledWith('household_session')
+    })
+
+    it('cookieがない場合もcookie削除は実行する', async () => {
+      mockCookies.get.mockReturnValueOnce(undefined)
+
+      await deleteSession()
+
+      expect(mockCookies.delete).toHaveBeenCalledWith('household_session')
+    })
+  })
+
+  describe('isAuthenticated', () => {
+    it('有効なセッションがあればtrueを返す', async () => {
+      mockCookies.get.mockReturnValueOnce({ value: 'valid-token' })
+
+      const futureDate = new Date(Date.now() + 86400000).toISOString()
+      mockSingleSuccess({ expires_at: futureDate })
+
+      const result = await isAuthenticated()
+
+      expect(result).toBe(true)
+    })
+
+    it('cookieがなければfalseを返す', async () => {
+      mockCookies.get.mockReturnValueOnce(undefined)
+
+      const result = await isAuthenticated()
+
+      expect(result).toBe(false)
+    })
+
+    it('DBにセッションがなければfalseを返す', async () => {
+      mockCookies.get.mockReturnValueOnce({ value: 'token' })
+      mockSingleSuccess(null)
+
+      const result = await isAuthenticated()
+
+      expect(result).toBe(false)
+    })
+
+    it('期限切れセッションはfalseを返す', async () => {
+      mockCookies.get.mockReturnValueOnce({ value: 'token' })
+
+      const pastDate = new Date(Date.now() - 86400000).toISOString()
+      mockSingleSuccess({ expires_at: pastDate })
+
+      const result = await isAuthenticated()
+
+      expect(result).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- 共有パスワードに加え、パスキー（WebAuthn）でのログインを実装
- セッション管理をcookie存在チェックからDB参照方式に変更し、ログイン時に夫/妻を自動判定
- 設定ページ（/settings）でパスキーの登録・削除が可能

## 変更内容

### 基盤
- `@simplewebauthn/server` / `@simplewebauthn/browser` v13 を追加
- DBマイグレーション: `sessions`, `passkey_credentials`, `webauthn_challenges` テーブル追加
- `src/lib/webauthn/config.ts`: RP設定ヘルパー
- `src/lib/webauthn/session.ts`: セッションCRUD（DB + cookie連携）

### 認証フロー
- `src/app/actions/auth.ts`: セッション管理をDB方式に移行（パスワードログインは引き続き動作）
- `src/app/actions/passkeys.ts`: パスキー登録/認証/管理のServer Actions
- Discoverable Credentials（Resident Keys）でログイン時にperson自動判定

### UI
- `/settings` ページ: パスキー管理UI（一覧・登録・削除）
- `/login` ページ: 「パスキーでログイン」ボタン追加
- ヘッダー: 設定アイコン（歯車）追加

## デプロイ前の手順
1. Supabaseで `005_webauthn_passkeys.sql` マイグレーション実行
2. 環境変数追加: `WEBAUTHN_RP_ID`, `WEBAUTHN_RP_ORIGIN`, `WEBAUTHN_RP_NAME`

## Test plan
- [x] 全258テスト通過（既存テスト含む）
- [x] 型チェック通過
- [x] ビルド成功
- [x] lint エラー 0
- [x] モックサーバーでログインページ表示確認（デスクトップ・モバイル）
- [x] パスワードログイン → メインページ遷移確認
- [x] 設定ページ表示確認（デスクトップ・モバイル）
- [x] ヘッダー設定アイコン表示確認
- [x] ログアウト → ログインページ遷移確認
- [ ] 実機でのパスキー登録・ログインテスト（WebAuthn APIはヘッドレスブラウザでテスト不可）