### PR TITLE
繰越コピーの重複登録を防止する

### DIFF
--- a/src/app/actions/copy-month.ts
+++ b/src/app/actions/copy-month.ts
@@ -10,6 +10,17 @@ import type {
   ActionResult,
 } from '@/types'
 
+type CarryoverInsertItem = {
+  month: string
+  label: string
+  amount: number
+  person: string
+}
+
+function getCarryoverCopyKey(item: Omit<CarryoverInsertItem, 'month'>): string {
+  return `${item.label}|${item.amount}|${item.person}`
+}
+
 /**
  * コピー操作のプレビューを取得
  * 収入・支出の項目リストと繰越件数を返す
@@ -134,20 +145,34 @@ async function copyCarryovers(
   if (mode === 'skip') {
     const { data: existingData } = await supabase
       .from('carryovers')
-      .select('label, person')
+      .select('label, amount, person')
       .eq('month', targetMonth)
 
     existingKeys = new Set(
-      (existingData ?? []).map((d) => `${d.label}|${d.person}`)
+      (existingData ?? []).map((d) => getCarryoverCopyKey(d))
     )
   }
 
-  const itemsToInsert: Array<{
-    month: string
-    label: string
-    amount: number
-    person: string
-  }> = []
+  const itemsToInsert: CarryoverInsertItem[] = []
+  const insertingKeys = new Set<string>()
+
+  const appendCarryover = (item: Omit<CarryoverInsertItem, 'month'>): void => {
+    const key = getCarryoverCopyKey(item)
+
+    if (existingKeys.has(key) || insertingKeys.has(key)) {
+      skipped++
+      return
+    }
+
+    insertingKeys.add(key)
+    itemsToInsert.push({
+      month: targetMonth,
+      label: item.label,
+      amount: item.amount,
+      person: item.person,
+    })
+    copied++
+  }
 
   // 繰越テーブルのレコードを処理（清算済みはスキップ）
   for (const item of carryoverResult.data ?? []) {
@@ -156,47 +181,24 @@ async function copyCarryovers(
       continue
     }
 
-    const key = `${item.label}|${item.person}`
-
-    if (mode === 'skip' && existingKeys.has(key)) {
-      skipped++
-      continue
-    }
-
-    itemsToInsert.push({
-      month: targetMonth,
-      label: item.label,
-      amount: item.amount,
-      person: item.person,
-    })
-    copied++
+    appendCarryover(item)
   }
 
   // 繰越フラグ付き支出も繰越としてコピー
   for (const item of carryoverExpenseResult.data ?? []) {
-    const key = `${item.label}|${item.person}`
-
-    if (mode === 'skip' && existingKeys.has(key)) {
-      skipped++
-      continue
-    }
-
-    itemsToInsert.push({
-      month: targetMonth,
-      label: item.label,
-      amount: item.amount,
-      person: item.person,
-    })
-    copied++
+    appendCarryover(item)
   }
 
   if (itemsToInsert.length > 0) {
-    const { error: insertError } = await supabase
+    const { error: upsertError } = await supabase
       .from('carryovers')
-      .insert(itemsToInsert)
+      .upsert(itemsToInsert, {
+        onConflict: 'month,label,amount,person',
+        ignoreDuplicates: true,
+      })
 
-    if (insertError) {
-      throw new Error(`繰越の挿入に失敗: ${insertError.message}`)
+    if (upsertError) {
+      throw new Error(`繰越の挿入に失敗: ${upsertError.message}`)
     }
   }
 

--- a/supabase/migrations/20260701151330_add_carryover_unique_index.sql
+++ b/supabase/migrations/20260701151330_add_carryover_unique_index.sql
@@ -1,0 +1,3 @@
+-- 同一月内で同じ繰越明細が重複登録されることを防ぐ
+CREATE UNIQUE INDEX IF NOT EXISTS idx_carryovers_unique_month_label_amount_person
+  ON carryovers(month, label, amount, person);

--- a/tests/integration/actions/copy-month.test.ts
+++ b/tests/integration/actions/copy-month.test.ts
@@ -8,7 +8,7 @@ import { mockRevalidatePath } from '../../../tests/mocks/next'
 import {
   copyMonthData,
 } from '@/app/actions/copy-month'
-import type { CopyMonthOptions, SelectedCopyItem } from '@/types'
+import type { CopyMonthOptions } from '@/types'
 
 describe('copy-month actions', () => {
   beforeEach(() => {
@@ -174,7 +174,7 @@ describe('copy-month actions', () => {
           error: null,
         })
 
-        qb.insert.mockResolvedValue({ data: null, error: null })
+        qb.upsert.mockResolvedValue({ data: null, error: null })
 
         const options: CopyMonthOptions = {
           sourceMonth: '202601',
@@ -211,6 +211,7 @@ describe('copy-month actions', () => {
         })
 
         qb.insert.mockResolvedValue({ data: null, error: null })
+        qb.upsert.mockResolvedValue({ data: null, error: null })
 
         const options: CopyMonthOptions = {
           sourceMonth: '202601',
@@ -234,6 +235,56 @@ describe('copy-month actions', () => {
         expect(result.success).toBe(true)
         expect(result.copied.expenses).toBe(1)
         expect(result.copied.carryovers).toBe(2)
+      })
+
+      it('同一キーの繰越はコピー時に1件へ重複排除される', async () => {
+        const qb = mockSupabaseClient._queryBuilder
+
+        qb.select.mockReturnValue(qb)
+        qb.eq.mockResolvedValueOnce({
+          data: [
+            { label: '前月繰越', amount: -10000, person: 'husband', is_cleared: false },
+            { label: '前月繰越', amount: -10000, person: 'husband', is_cleared: false },
+          ],
+          error: null,
+        })
+        qb.eq.mockReturnValueOnce(qb)
+        qb.eq.mockResolvedValueOnce({
+          data: [
+            { label: '前月繰越', amount: -10000, person: 'husband' },
+          ],
+          error: null,
+        })
+
+        qb.upsert.mockResolvedValue({ data: null, error: null })
+
+        const options: CopyMonthOptions = {
+          sourceMonth: '202601',
+          targetMonth: '202602',
+          mode: 'add',
+          selectedItems: [],
+          includeCarryover: true,
+        }
+
+        const result = await copyMonthData(options)
+
+        expect(result.success).toBe(true)
+        expect(result.copied.carryovers).toBe(1)
+        expect(result.skipped.carryovers).toBe(2)
+        expect(qb.upsert).toHaveBeenCalledWith(
+          [
+            {
+              month: '202602',
+              label: '前月繰越',
+              amount: -10000,
+              person: 'husband',
+            },
+          ],
+          {
+            onConflict: 'month,label,amount,person',
+            ignoreDuplicates: true,
+          }
+        )
       })
     })
 
@@ -338,8 +389,8 @@ describe('copy-month actions', () => {
           error: null,
         })
 
-        // insertの結果
-        qb.insert.mockResolvedValue({ data: null, error: null })
+        // upsertの結果
+        qb.upsert.mockResolvedValue({ data: null, error: null })
 
         const options: CopyMonthOptions = {
           sourceMonth: '202601',
@@ -372,8 +423,8 @@ describe('copy-month actions', () => {
           error: null,
         })
 
-        // insertの結果
-        qb.insert.mockResolvedValue({ data: null, error: null })
+        // upsertの結果
+        qb.upsert.mockResolvedValue({ data: null, error: null })
 
         const options: CopyMonthOptions = {
           sourceMonth: '202601',
@@ -531,7 +582,7 @@ describe('copy-month actions', () => {
         })
 
         // 繰越挿入は失敗
-        qb.insert.mockResolvedValueOnce({
+        qb.upsert.mockResolvedValueOnce({
           data: null,
           error: { message: 'Insert failed' },
         })

--- a/tests/mocks/supabase.ts
+++ b/tests/mocks/supabase.ts
@@ -10,6 +10,7 @@ export interface SupabaseResponse<T = unknown> {
 export interface MockQueryBuilder {
   select: Mock
   insert: Mock
+  upsert: Mock
   update: Mock
   delete: Mock
   eq: Mock
@@ -23,6 +24,7 @@ export function createMockQueryBuilder(): MockQueryBuilder {
   const builder: MockQueryBuilder = {
     select: vi.fn(),
     insert: vi.fn(),
+    upsert: vi.fn(),
     update: vi.fn(),
     delete: vi.fn(),
     eq: vi.fn(),
@@ -34,6 +36,7 @@ export function createMockQueryBuilder(): MockQueryBuilder {
   // 各メソッドがビルダー自身を返すように設定
   builder.select.mockReturnValue(builder)
   builder.insert.mockReturnValue(builder)
+  builder.upsert.mockReturnValue(builder)
   builder.update.mockReturnValue(builder)
   builder.delete.mockReturnValue(builder)
   builder.eq.mockReturnValue(builder)
@@ -146,6 +149,7 @@ export function clearSupabaseMocks() {
   mockSupabaseClient.from.mockClear()
   qb.select.mockClear()
   qb.insert.mockClear()
+  qb.upsert.mockClear()
   qb.update.mockClear()
   qb.delete.mockClear()
   qb.eq.mockClear()


### PR DESCRIPTION
## Summary
- 繰越コピー時に `label`・`amount`・`person` で重複を判定し、同一キーの項目を1件にまとめるように変更
- `carryovers` に月内重複を防ぐユニークインデックスを追加
- Supabase の挿入処理を `upsert` ベースに切り替え、重複排除の挙動をテストで補強

## Testing
- 単体・統合テストで、繰越の重複排除とコピー結果の件数を確認
- 既存のコピー処理の正常系とエラー系も含めて検証