### PR TITLE
fix: ログインリダイレクトループを解消

### DIFF
--- a/src/app/login/login-form.tsx
+++ b/src/app/login/login-form.tsx
@@ -1,0 +1,109 @@
+'use client'
+
+import { useActionState, useState } from 'react'
+import { login } from '@/app/actions/auth'
+import { ThemeToggle } from '@/components/ui/theme-toggle'
+import { PasskeyLoginButton } from '@/features/passkey/components/passkey-login-button'
+
+export function LoginForm() {
+  const [state, formAction, isPending] = useActionState(login, {})
+  const [showPassword, setShowPassword] = useState(false)
+
+  return (
+    <div className="min-h-screen bg-background flex flex-col">
+      {/* ヘッダー */}
+      <header className="flex items-center justify-between px-5 py-3.5 border-b border-border">
+        <span className="text-[11px] font-bold tracking-[0.18em] uppercase text-sub-text">
+          Score Splitter
+        </span>
+        <ThemeToggle />
+      </header>
+
+      {/* メイン */}
+      <main id="main" tabIndex={-1} className="flex-1 px-5 pt-10 pb-4 flex flex-col max-w-md mx-auto w-full">
+        {/* ヒーロー */}
+        <section className="pb-6">
+          <div className="w-12 h-12 rounded-[12px] bg-accent text-accent-foreground flex items-center justify-center">
+            <span className="text-[22px] font-bold">S</span>
+          </div>
+          <h1 className="text-[22px] font-bold leading-[1.05] mt-4">
+            Score Splitter
+          </h1>
+          <p className="text-[13px] text-sub-text mt-2.5 leading-relaxed">
+            パスワードを入力してログインしてください。
+            <br />
+            セッションは7日間保持されます。
+          </p>
+        </section>
+
+        {/* パスワードフォーム */}
+        <div className="rounded-[20px] shadow-soft-lg p-[18px]">
+          <form action={formAction} className="flex flex-col gap-3.5">
+            <div>
+              <div className="flex items-baseline justify-between mb-2">
+                <label
+                  htmlFor="password"
+                  className="text-[11px] font-bold tracking-[0.14em] uppercase text-sub-text"
+                >
+                  パスワード
+                </label>
+                <span className="text-[10px] text-sub-text font-tabular">
+                  パスワードの表示状態: {showPassword ? '表示' : '非表示'}
+                </span>
+              </div>
+
+              <div className="rounded-[12px] bg-muted flex items-center px-4 h-12">
+                <input
+                  id="password"
+                  type={showPassword ? 'text' : 'password'}
+                  name="password"
+                  placeholder="パスワード"
+                  required
+                  autoFocus
+                  className="flex-1 text-[20px] font-semibold tracking-[0.30em] bg-transparent border-none outline-none font-tabular placeholder:text-muted-foreground/40 placeholder:tracking-normal placeholder:text-base"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword((prev) => !prev)}
+                  className="text-[11px] font-bold tracking-[0.10em] uppercase text-accent shrink-0"
+                >
+                  {showPassword ? '隠す' : '表示'}
+                </button>
+              </div>
+            </div>
+
+            {state.error && (
+              <div className="flex items-center gap-2">
+                <span className="w-1.5 h-1.5 rounded-full bg-destructive shrink-0" />
+                <span className="text-[12px] font-semibold text-destructive">{state.error}</span>
+              </div>
+            )}
+
+            <button
+              type="submit"
+              disabled={isPending}
+              className="mt-1 h-12 px-5 bg-accent text-accent-foreground rounded-[12px] text-[13px] font-bold tracking-[0.14em] uppercase flex items-center justify-between shadow-fab disabled:opacity-50 transition-opacity"
+            >
+              <span>{isPending ? 'ログイン中…' : 'ログイン'}</span>
+              {!isPending && <span className="text-lg font-normal">→</span>}
+            </button>
+          </form>
+
+          {/* パスキーログイン */}
+          <div className="mt-4">
+            <PasskeyLoginButton />
+          </div>
+        </div>
+      </main>
+
+      {/* フッター */}
+      <footer className="px-5 py-5">
+        <p className="text-[11px] text-sub-text leading-relaxed">
+          パスワードを忘れた場合は
+          <br />
+          管理者に問い合わせてください。
+        </p>
+      </footer>
+    </div>
+  )
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,110 +1,11 @@
-'use client'
+import { redirect } from 'next/navigation'
+import { LoginForm } from './login-form'
+import { isAuthenticated } from '@/lib/webauthn/session'
 
-import { useState } from 'react'
-import { useActionState } from 'react'
-import { login } from '@/app/actions/auth'
-import { ThemeToggle } from '@/components/ui/theme-toggle'
-import { PasskeyLoginButton } from '@/features/passkey/components/passkey-login-button'
+export default async function LoginPage() {
+  if (await isAuthenticated()) {
+    redirect('/')
+  }
 
-export default function LoginPage() {
-  const [state, formAction, isPending] = useActionState(login, {})
-  const [showPassword, setShowPassword] = useState(false)
-
-  return (
-    <div className="min-h-screen bg-background flex flex-col">
-      {/* ヘッダー */}
-      <header className="flex items-center justify-between px-5 py-3.5 border-b border-border">
-        <span className="text-[11px] font-bold tracking-[0.18em] uppercase text-sub-text">
-          Score Splitter
-        </span>
-        <ThemeToggle />
-      </header>
-
-      {/* メイン */}
-      <main id="main" tabIndex={-1} className="flex-1 px-5 pt-10 pb-4 flex flex-col max-w-md mx-auto w-full">
-        {/* ヒーロー */}
-        <section className="pb-6">
-          <div className="w-12 h-12 rounded-[12px] bg-accent text-accent-foreground flex items-center justify-center">
-            <span className="text-[22px] font-bold">S</span>
-          </div>
-          <h1 className="text-[22px] font-bold leading-[1.05] mt-4">
-            Score Splitter
-          </h1>
-          <p className="text-[13px] text-sub-text mt-2.5 leading-relaxed">
-            パスワードを入力してログインしてください。
-            <br />
-            セッションは7日間保持されます。
-          </p>
-        </section>
-
-        {/* パスワードフォーム */}
-        <div className="rounded-[20px] shadow-soft-lg p-[18px]">
-          <form action={formAction} className="flex flex-col gap-3.5">
-            <div>
-              <div className="flex items-baseline justify-between mb-2">
-                <label
-                  htmlFor="password"
-                  className="text-[11px] font-bold tracking-[0.14em] uppercase text-sub-text"
-                >
-                  パスワード
-                </label>
-                <span className="text-[10px] text-sub-text font-tabular">
-                  パスワードの表示状態: {showPassword ? '表示' : '非表示'}
-                </span>
-              </div>
-
-              <div className="rounded-[12px] bg-muted flex items-center px-4 h-12">
-                <input
-                  id="password"
-                  type={showPassword ? 'text' : 'password'}
-                  name="password"
-                  placeholder="パスワード"
-                  required
-                  autoFocus
-                  className="flex-1 text-[20px] font-semibold tracking-[0.30em] bg-transparent border-none outline-none font-tabular placeholder:text-muted-foreground/40 placeholder:tracking-normal placeholder:text-base"
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowPassword((prev) => !prev)}
-                  className="text-[11px] font-bold tracking-[0.10em] uppercase text-accent shrink-0"
-                >
-                  {showPassword ? '隠す' : '表示'}
-                </button>
-              </div>
-            </div>
-
-            {state.error && (
-              <div className="flex items-center gap-2">
-                <span className="w-1.5 h-1.5 rounded-full bg-destructive shrink-0" />
-                <span className="text-[12px] font-semibold text-destructive">{state.error}</span>
-              </div>
-            )}
-
-            <button
-              type="submit"
-              disabled={isPending}
-              className="mt-1 h-12 px-5 bg-accent text-accent-foreground rounded-[12px] text-[13px] font-bold tracking-[0.14em] uppercase flex items-center justify-between shadow-fab disabled:opacity-50 transition-opacity"
-            >
-              <span>{isPending ? 'ログイン中…' : 'ログイン'}</span>
-              {!isPending && <span className="text-lg font-normal">→</span>}
-            </button>
-          </form>
-
-          {/* パスキーログイン */}
-          <div className="mt-4">
-            <PasskeyLoginButton />
-          </div>
-        </div>
-      </main>
-
-      {/* フッター */}
-      <footer className="px-5 py-5">
-        <p className="text-[11px] text-sub-text leading-relaxed">
-          パスワードを忘れた場合は
-          <br />
-          管理者に問い合わせてください。
-        </p>
-      </footer>
-    </div>
-  )
+  return <LoginForm />
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -10,10 +10,8 @@ export function middleware(request: NextRequest) {
 
   // ログインページにアクセスしようとしている場合
   if (isLoginPage) {
-    // すでにログイン済みならトップページへ
-    if (hasSession) {
-      return NextResponse.redirect(new URL('/', request.url))
-    }
+    // middlewareではDBの実セッションを検証できないため、ログインページ側で判定する。
+    // 古いCookieをここでログイン済み扱いすると /login と / のリダイレクトループになる。
     return NextResponse.next()
   }
 

--- a/tests/components/login-page.test.tsx
+++ b/tests/components/login-page.test.tsx
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
+import { redirect } from 'next/navigation'
 import LoginPage from '@/app/login/page'
+import { isAuthenticated } from '@/lib/webauthn/session'
 
 vi.mock('next-themes', () => ({
   useTheme: () => ({
@@ -12,17 +14,37 @@ vi.mock('@/app/actions/auth', () => ({
   login: vi.fn(),
 }))
 
+vi.mock('@/lib/webauthn/session', () => ({
+  isAuthenticated: vi.fn(),
+}))
+
+vi.mock('next/navigation', () => ({
+  redirect: vi.fn((path: string) => {
+    throw new Error(`NEXT_REDIRECT:${path}`)
+  }),
+}))
+
 vi.mock('@/features/passkey/components/passkey-login-button', () => ({
   PasskeyLoginButton: () => <button type="button">パスキーでログイン</button>,
 }))
 
 describe('LoginPage', () => {
-  it('アプリ名と補助文言をScore Splitterに統一する', () => {
-    render(<LoginPage />)
+  it('未認証の場合はログインフォームを表示する', async () => {
+    vi.mocked(isAuthenticated).mockResolvedValue(false)
+
+    render(await LoginPage())
 
     expect(screen.getByRole('heading', { name: 'Score Splitter' })).toBeInTheDocument()
     expect(screen.queryByText('家計計算アプリ')).not.toBeInTheDocument()
     expect(screen.getByText('パスワードの表示状態: 非表示')).toBeInTheDocument()
     expect(screen.queryByText('Help ›')).not.toBeInTheDocument()
+  })
+
+  it('認証済みの場合はトップページへリダイレクトする', async () => {
+    vi.mocked(isAuthenticated).mockResolvedValue(true)
+
+    await expect(LoginPage()).rejects.toThrow('NEXT_REDIRECT:/')
+
+    expect(redirect).toHaveBeenCalledWith('/')
   })
 })

--- a/tests/unit/middleware.test.ts
+++ b/tests/unit/middleware.test.ts
@@ -32,4 +32,10 @@ describe('middleware', () => {
 
     expect(response.headers.get('location')).toBeNull()
   })
+
+  it('有効な形式のセッションCookieでもログインページは通す', () => {
+    const response = middleware(createRequest('/login', VALID_SESSION_TOKEN))
+
+    expect(response.headers.get('location')).toBeNull()
+  })
 })


### PR DESCRIPTION
## 概要
- middleware のログイン済み判定を保護ページの一次判定に限定し、古い形式-valid Cookie による /login と / のリダイレクトループを解消
- /login を Server Component 化し、実セッション確認後のみトップページへリダイレクト
- ログインフォームを Client Component に分離し、関連テストを追加

## テスト
- npm run test:run
- npm run lint
- npm run build
- npm run dev:mock で /login 表示、パスワード表示切替、古い Cookie 付き /login のリダイレクトなしを確認