### PR TITLE
feat: Worker APIに api.yamawake.app カスタムドメインを追加

### DIFF
--- a/cloudflare/worker/wrangler.jsonc
+++ b/cloudflare/worker/wrangler.jsonc
@@ -5,6 +5,8 @@
   "compatibility_date": "2026-06-28",
   "workers_dev": true,
   "preview_urls": true,
+  // カスタムドメイン。ゾーン（yamawake.app）が同一アカウントにあるためdeploy時にDNSレコードが自動作成される
+  "routes": [{ "pattern": "api.yamawake.app", "custom_domain": true }],
   "d1_databases": [
     {
       "binding": "DB",


### PR DESCRIPTION
## 概要

yamawake.app ドメイン設定の第1段（PR-A）。Worker API（score-splitter-api）に Cloudflare Custom Domain `api.yamawake.app` を割り当てる。

- `cloudflare/worker/wrangler.jsonc` に `routes`（`api.yamawake.app`, `custom_domain: true`）を追記
- ゾーン yamawake.app は同一アカウントにあるため、deploy時にDNSレコードが自動作成される
- フロントは引き続き旧 workers.dev URL を参照するため、このPR単体では無停止（フロント切替は後続のPR-B）

## デプロイ前の確認（手作業）

Cloudflareダッシュボード → yamawake.app ゾーン → DNS で `api` に競合レコードが無いこと（あるとdeployがコンフリクトで失敗）

## テスト計画

- [ ] マージ後、Workers Builds の自動デプロイ成功を確認
- [ ] `curl -i https://api.yamawake.app/sessions` でWorker応答（401 = Bearer認証必須）を確認
- [ ] 旧URL `https://score-splitter-api.yosket87.workers.dev` も引き続き応答すること（フロントが参照中）