### PR TITLE
アプリテーマをLPテイストに統一

### DIFF
--- a/src/app/[year]/[month]/page.tsx
+++ b/src/app/[year]/[month]/page.tsx
@@ -46,7 +46,7 @@ export default async function MonthPage({ params }: MonthPageProps) {
   const recentSummaries = allSummaries.slice(0, 6)
 
   return (
-    <div className="min-h-screen bg-background">
+    <div className="min-h-screen gradient-page">
       <HeroSection
         currentMonth={month}
         incomes={incomes}

--- a/src/app/[year]/page.tsx
+++ b/src/app/[year]/page.tsx
@@ -24,7 +24,7 @@ export default async function YearPage({ params }: YearPageProps) {
   const summaries = summariesResult.data ?? []
 
   return (
-    <div className="min-h-screen bg-background">
+    <div className="min-h-screen gradient-page">
       <Header />
       <main
         id="main"

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -16,11 +16,7 @@ export default function Error({ error, reset }: ErrorProps) {
   }, [error])
 
   return (
-    <main id="main" tabIndex={-1} className="min-h-screen gradient-page flex items-center justify-center">
-      <div className="absolute inset-0 overflow-hidden pointer-events-none">
-        <div className="absolute -top-40 -right-40 w-80 h-80 rounded-full bg-destructive/10 blur-3xl" />
-        <div className="absolute -bottom-40 -left-40 w-80 h-80 rounded-full bg-accent/5 blur-3xl" />
-      </div>
+    <main id="main" tabIndex={-1} className="min-h-screen gradient-page flex items-center justify-center px-5">
       <Card className="w-full max-w-md relative glow-md animate-fade-in">
         <CardContent className="pt-8 pb-8">
           <div className="text-center space-y-4">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -54,6 +54,8 @@
   --color-wife-light: var(--wife-light);
   --color-neon-red-light: var(--neon-red-light);
   --color-neon-cyan-light: var(--neon-cyan-light);
+  --color-brand-orange: var(--brand-orange);
+  --color-brand-orange-light: var(--brand-orange-light);
   --color-chart-bar-muted: var(--chart-bar-muted);
   --color-warning: var(--warning);
   --color-sub-text: var(--sub-text);
@@ -65,98 +67,100 @@
 
   /* 背景系 */
   --background: #FAFBFC;
-  --foreground: #1A1A1A;
+  --foreground: #0F172A;
   --card: #FFFFFF;
-  --card-foreground: #1A1A1A;
+  --card-foreground: #0F172A;
   --popover: #FFFFFF;
-  --popover-foreground: #1A1A1A;
+  --popover-foreground: #0F172A;
 
   /* サブテキスト */
-  --sub-text: #666666;
+  --sub-text: #64748B;
 
   /* プライマリ */
-  --primary: #1A1A1A;
+  --primary: #0F172A;
   --primary-foreground: #FFFFFF;
 
   /* セカンダリ */
-  --secondary: #F3F4F6;
-  --secondary-foreground: #1A1A1A;
+  --secondary: #F0F9FF;
+  --secondary-foreground: #0F172A;
 
   /* ミュート */
-  --muted: #F3F4F6;
-  --muted-foreground: #767676;
+  --muted: #F1F5F9;
+  --muted-foreground: #64748B;
 
-  /* アクセント — ブルー */
-  --accent: #2563EB;
+  /* アクセント — LPと同じsky系 */
+  --accent: #0369A1;
   --accent-foreground: #FFFFFF;
+  --brand-orange: #EA580C;
+  --brand-orange-light: #FFEDD5;
 
   /* デストラクティブ */
   --destructive: #E2483D;
 
   /* ボーダー・入力 */
-  --border: #E5E7EB;
-  --input: #F3F4F6;
-  --ring: #2563EB;
+  --border: #E2E8F0;
+  --input: #F1F5F9;
+  --ring: #0EA5E9;
 
   /* ドメインカラー */
   --neon-red: #E2483D;
-  --neon-cyan: #2563EB;
+  --neon-cyan: #0369A1;
 
   /* 担当者カラー */
-  --husband: #3B82F6;
-  --husband-light: #DBEAFE;
-  --wife: #EF4444;
-  --wife-light: #FEE2E2;
+  --husband: #0284C7;
+  --husband-light: #E0F2FE;
+  --wife: #F97316;
+  --wife-light: #FFEDD5;
 
   /* シャドウ効果 */
-  --glow-accent: #2563EB;
-  --glow-sm: 0 1px 3px #00000014;
-  --glow-md: 0 2px 8px #0000001A;
-  --glow-lg: 0 4px 16px #0000001F;
+  --glow-accent: #0EA5E9;
+  --glow-sm: 0 2px 8px #0EA5E926;
+  --glow-md: 0 6px 18px #0EA5E92E;
+  --glow-lg: 0 10px 28px #0EA5E936;
 
   /* Soft Cards シャドウ */
-  --shadow-soft: 0 2px 8px #0000000D, 0 0 0 1px #E5E7EB;
-  --shadow-soft-lg: 0 4px 16px #0000000D, 0 0 0 1px #E5E7EB;
-  --shadow-fab: 0 4px 12px #2563EB33;
+  --shadow-soft: 0 2px 8px #0F172A0D, 0 0 0 1px #E2E8F0;
+  --shadow-soft-lg: 0 8px 24px #0F172A12, 0 0 0 1px #E2E8F0;
+  --shadow-fab: 0 8px 20px #0369A133, 0 2px 6px #EA580C1F;
 
   /* カードシャドウ */
-  --shadow-card: 0 2px 8px #0000000D, 0 0 0 1px #E5E7EB;
-  --shadow-card-hover: 0 8px 22px #2563EB2E, 0 0 0 1.5px #2563EB;
+  --shadow-card: 0 2px 8px #0F172A0D, 0 0 0 1px #E2E8F0;
+  --shadow-card-hover: 0 8px 22px #0369A12E, 0 0 0 1.5px #0EA5E9;
 
   /* サーフェス */
-  --surface-chip: #F3F4F6;
-  --surface-total: #FAFBFC;
+  --surface-chip: #F0F9FF;
+  --surface-total: #F8FAFC;
 
   /* ドメインカラー（ライト版） */
   --neon-red-light: #FFE8E6;
-  --neon-cyan-light: #EFF6FF;
+  --neon-cyan-light: #E0F2FE;
 
   /* 担当者カラー（ソリッド） */
-  --gradient-husband: #3B82F6;
-  --gradient-wife: #EF4444;
+  --gradient-husband: #0EA5E9;
+  --gradient-wife: #F97316;
 
   /* チャートバー（非カレント） */
   --chart-bar-muted: #E5E7EB;
 
   /* 警告カラー */
-  --warning: #F59E0B;
+  --warning: #EA580C;
 
   /* チャート */
-  --chart-1: #2563EB;
-  --chart-2: #3B82F6;
-  --chart-3: #2563EB;
-  --chart-4: #EF4444;
-  --chart-5: #E2483D;
+  --chart-1: #0369A1;
+  --chart-2: #0EA5E9;
+  --chart-3: #F97316;
+  --chart-4: #FB7185;
+  --chart-5: #EA580C;
 
   /* サイドバー（互換性のため） */
-  --sidebar: #F3F4F6;
-  --sidebar-foreground: #1A1A1A;
-  --sidebar-primary: #2563EB;
+  --sidebar: #F0F9FF;
+  --sidebar-foreground: #0F172A;
+  --sidebar-primary: #0369A1;
   --sidebar-primary-foreground: #FFFFFF;
-  --sidebar-accent: #F3F4F6;
-  --sidebar-accent-foreground: #1A1A1A;
-  --sidebar-border: #E5E7EB;
-  --sidebar-ring: #2563EB;
+  --sidebar-accent: #E0F2FE;
+  --sidebar-accent-foreground: #0F172A;
+  --sidebar-border: #E2E8F0;
+  --sidebar-ring: #0EA5E9;
 }
 
 /* ===== ダークモード ===== */
@@ -182,8 +186,10 @@
   --muted-foreground: #9CA3AF;
 
   /* アクセント — ブルー（ダーク版） */
-  --accent: #60A5FA;
-  --accent-foreground: #0F1117;
+  --accent: #38BDF8;
+  --accent-foreground: #082F49;
+  --brand-orange: #FDBA74;
+  --brand-orange-light: #F9731626;
 
   /* デストラクティブ */
   --destructive: #F87171;
@@ -191,35 +197,35 @@
   /* ボーダー・入力 */
   --border: #ffffff14;
   --input: #ffffff1F;
-  --ring: #60A5FA;
+  --ring: #38BDF8;
 
   /* サブテキスト */
   --sub-text: #9CA3AF;
 
   /* ドメインカラー */
   --neon-red: #F87171;
-  --neon-cyan: #60A5FA;
+  --neon-cyan: #38BDF8;
 
   /* 担当者カラー */
-  --husband: #60A5FA;
-  --husband-light: #60A5FA26;
-  --wife: #FB7185;
-  --wife-light: #FB718526;
+  --husband: #38BDF8;
+  --husband-light: #0EA5E926;
+  --wife: #FDBA74;
+  --wife-light: #F9731626;
 
   /* グロー効果（ダーク用） */
-  --glow-accent: #60A5FA;
-  --glow-sm: 0 0 8px #60A5FA26;
-  --glow-md: 0 0 16px #60A5FA33;
-  --glow-lg: 0 0 24px #60A5FA40;
+  --glow-accent: #38BDF8;
+  --glow-sm: 0 0 8px #38BDF826;
+  --glow-md: 0 0 16px #38BDF833;
+  --glow-lg: 0 0 24px #38BDF840;
 
   /* Soft Cards シャドウ（ダーク用） */
   --shadow-soft: 0 4px 14px #0000004D, 0 0 1px #ffffff0D;
   --shadow-soft-lg: 0 8px 24px #00000059, 0 0 1px #ffffff14;
-  --shadow-fab: 0 4px 12px #60A5FA4D;
+  --shadow-fab: 0 8px 20px #38BDF84D, 0 2px 8px #FDBA7426;
 
   /* カードシャドウ（ダーク用） */
   --shadow-card: 0 4px 14px #0000004D, 0 0 1px #ffffff0D;
-  --shadow-card-hover: 0 8px 22px #60A5FA2E, 0 0 1px #ffffff14;
+  --shadow-card-hover: 0 8px 22px #38BDF82E, 0 0 1px #ffffff14;
 
   /* サーフェス（ダーク用） */
   --surface-chip: #252833;
@@ -227,34 +233,34 @@
 
   /* ドメインカラー（ダーク版） */
   --neon-red-light: #F8717126;
-  --neon-cyan-light: #60A5FA26;
+  --neon-cyan-light: #38BDF826;
 
   /* 担当者カラー（ダーク版） */
-  --gradient-husband: #60A5FA;
-  --gradient-wife: #FB7185;
+  --gradient-husband: #38BDF8;
+  --gradient-wife: #FDBA74;
 
   /* チャートバー（非カレント・ダーク版） */
   --chart-bar-muted: #374151;
 
   /* 警告カラー */
-  --warning: #FBBF24;
+  --warning: #FDBA74;
 
   /* チャート */
-  --chart-1: #60A5FA;
-  --chart-2: #34D399;
-  --chart-3: #60A5FA;
+  --chart-1: #38BDF8;
+  --chart-2: #7DD3FC;
+  --chart-3: #FDBA74;
   --chart-4: #FB7185;
-  --chart-5: #F87171;
+  --chart-5: #F97316;
 
   /* サイドバー（互換性のため） */
   --sidebar: #1A1D27;
   --sidebar-foreground: #E5E7EB;
-  --sidebar-primary: #60A5FA;
+  --sidebar-primary: #38BDF8;
   --sidebar-primary-foreground: #0F1117;
   --sidebar-accent: #252833;
   --sidebar-accent-foreground: #E5E7EB;
   --sidebar-border: #ffffff14;
-  --sidebar-ring: #60A5FA;
+  --sidebar-ring: #38BDF8;
 }
 
 @layer base {
@@ -302,6 +308,16 @@
 
 @utility gradient-fab {
   background: var(--accent);
+}
+
+@utility gradient-page {
+  background:
+    linear-gradient(
+      to bottom,
+      color-mix(in srgb, var(--accent) 8%, var(--background)) 0%,
+      var(--background) 48%,
+      color-mix(in srgb, var(--brand-orange) 6%, var(--background)) 100%
+    );
 }
 
 @utility shadow-card {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,7 +12,7 @@ export const metadata: Metadata = {
 export const viewport: Viewport = {
   viewportFit: 'cover',
   themeColor: [
-    { media: '(prefers-color-scheme: light)', color: '#4C3BCF' },
+    { media: '(prefers-color-scheme: light)', color: '#F0F9FF' },
     { media: '(prefers-color-scheme: dark)', color: '#0F1117' },
   ],
 }

--- a/src/app/login/login-form.tsx
+++ b/src/app/login/login-form.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useActionState, useState } from 'react'
+import { ArrowRight } from 'lucide-react'
 import { login } from '@/app/actions/auth'
 import { ThemeToggle } from '@/components/ui/theme-toggle'
 import { PasskeyLoginButton } from '@/features/passkey/components/passkey-login-button'
@@ -10,9 +11,9 @@ export function LoginForm() {
   const [showPassword, setShowPassword] = useState(false)
 
   return (
-    <div className="min-h-screen bg-background flex flex-col">
+    <div className="min-h-screen gradient-page flex flex-col">
       {/* ヘッダー */}
-      <header className="flex items-center justify-between px-5 py-3.5 border-b border-border">
+      <header className="flex items-center justify-between border-b border-border bg-background/80 px-5 py-3.5 backdrop-blur">
         <span className="text-[11px] font-bold tracking-[0.18em] uppercase text-sub-text">
           Score Splitter
         </span>
@@ -23,7 +24,7 @@ export function LoginForm() {
       <main id="main" tabIndex={-1} className="flex-1 px-5 pt-10 pb-4 flex flex-col max-w-md mx-auto w-full">
         {/* ヒーロー */}
         <section className="pb-6">
-          <div className="w-12 h-12 rounded-[12px] bg-accent text-accent-foreground flex items-center justify-center">
+          <div className="w-12 h-12 rounded-[12px] bg-gradient-to-br from-sky-700 to-orange-600 text-white flex items-center justify-center shadow-fab dark:from-sky-300 dark:to-orange-300 dark:text-slate-950">
             <span className="text-[22px] font-bold">S</span>
           </div>
           <h1 className="text-[22px] font-bold leading-[1.05] mt-4">
@@ -37,7 +38,7 @@ export function LoginForm() {
         </section>
 
         {/* パスワードフォーム */}
-        <div className="rounded-[20px] shadow-soft-lg p-[18px]">
+        <div className="rounded-[20px] border border-sky-100/80 bg-card/95 p-[18px] shadow-soft-lg dark:border-white/10">
           <form action={formAction} className="flex flex-col gap-3.5">
             <div>
               <div className="flex items-baseline justify-between mb-2">
@@ -52,7 +53,7 @@ export function LoginForm() {
                 </span>
               </div>
 
-              <div className="rounded-[12px] bg-muted flex items-center px-4 h-12">
+              <div className="rounded-[12px] bg-sky-50/80 flex items-center px-4 h-12 dark:bg-muted">
                 <input
                   id="password"
                   type={showPassword ? 'text' : 'password'}
@@ -82,10 +83,15 @@ export function LoginForm() {
             <button
               type="submit"
               disabled={isPending}
-              className="mt-1 h-12 px-5 bg-accent text-accent-foreground rounded-[12px] text-[13px] font-bold tracking-[0.14em] uppercase flex items-center justify-between shadow-fab disabled:opacity-50 transition-opacity"
+              className="mt-1 h-12 px-5 bg-accent text-accent-foreground rounded-[12px] text-[13px] font-bold tracking-[0.14em] uppercase flex items-center justify-between shadow-fab disabled:opacity-50 transition-colors hover:bg-sky-700 dark:hover:bg-sky-300"
             >
               <span>{isPending ? 'ログイン中…' : 'ログイン'}</span>
-              {!isPending && <span className="text-lg font-normal">→</span>}
+              {!isPending && (
+                <ArrowRight
+                  className="h-4 w-4 text-orange-100 dark:text-orange-950"
+                  aria-hidden="true"
+                />
+              )}
             </button>
           </form>
 

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -5,11 +5,7 @@ import { Card, CardContent } from '@/components/ui/card'
 
 export default function NotFound() {
   return (
-    <main id="main" tabIndex={-1} className="min-h-screen gradient-page flex items-center justify-center">
-      <div className="absolute inset-0 overflow-hidden pointer-events-none">
-        <div className="absolute -top-40 -right-40 w-80 h-80 rounded-full bg-accent/10 blur-3xl" />
-        <div className="absolute -bottom-40 -left-40 w-80 h-80 rounded-full bg-accent/5 blur-3xl" />
-      </div>
+    <main id="main" tabIndex={-1} className="min-h-screen gradient-page flex items-center justify-center px-5">
       <Card className="w-full max-w-md relative glow-md animate-fade-in">
         <CardContent className="pt-8 pb-8">
           <div className="text-center space-y-4">

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -8,12 +8,12 @@ export default async function SettingsPage() {
   await requireAuth()
 
   return (
-    <div className="min-h-screen bg-background flex flex-col">
-      <header className="flex items-center justify-between px-5 py-3.5 border-b border-border">
+    <div className="min-h-screen gradient-page flex flex-col">
+      <header className="flex items-center justify-between border-b border-border bg-background/80 px-5 py-3.5 backdrop-blur">
         <div className="flex items-center gap-2">
           <Link
             href="/"
-            className="text-sub-text hover:text-accent transition-colors"
+            className="inline-flex h-9 w-9 items-center justify-center rounded-full text-sub-text transition-colors hover:bg-sky-50 hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 dark:hover:bg-white/10"
             aria-label="戻る"
           >
             <ArrowLeft className="h-4 w-4" />
@@ -29,7 +29,9 @@ export default async function SettingsPage() {
         <h1 className="text-[18px] font-bold tracking-[-0.02em] mb-6">
           パスキー管理
         </h1>
-        <PasskeySettings />
+        <div className="rounded-[20px] border border-sky-100/80 bg-card/95 p-5 shadow-soft-lg dark:border-white/10">
+          <PasskeySettings />
+        </div>
       </main>
     </div>
   )

--- a/src/components/layout/header-actions.tsx
+++ b/src/components/layout/header-actions.tsx
@@ -12,7 +12,7 @@ interface HeaderActionsProps {
 
 export function HeaderActions({ variant = 'default' }: HeaderActionsProps) {
   const iconClass = variant === 'hero'
-    ? 'text-white/70 hover:text-white'
+    ? 'text-sky-900/70 hover:text-sky-950 dark:text-white/70 dark:hover:text-white'
     : 'text-muted-foreground hover:text-accent'
 
   return (

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -4,7 +4,7 @@ import { HeaderActions } from '@/components/layout/header-actions'
 
 export function Header() {
   return (
-    <header className="bg-background">
+    <header className="border-b border-border bg-background/80 backdrop-blur">
       <div className="px-5 py-4 flex items-center justify-between max-w-4xl mx-auto">
         <span className="text-[12px] font-bold tracking-[1px] uppercase text-foreground">
           Score Splitter

--- a/src/features/add-entry/components/add-entry-form.tsx
+++ b/src/features/add-entry/components/add-entry-form.tsx
@@ -77,7 +77,10 @@ export function AddEntryForm({ type, month, onSuccess, onCancel }: AddEntryFormP
         >
           キャンセル
         </Button>
-        <SubmitButton className="flex-1 h-12" pendingChildren="追加中...">
+        <SubmitButton
+          className="flex-1 h-12 bg-accent text-accent-foreground shadow-fab hover:bg-sky-700 dark:hover:bg-sky-300"
+          pendingChildren="追加中..."
+        >
           {TYPE_LABELS[type]}を追加
         </SubmitButton>
       </div>

--- a/src/features/add-entry/components/add-entry-sheet.tsx
+++ b/src/features/add-entry/components/add-entry-sheet.tsx
@@ -166,7 +166,7 @@ export function AddEntrySheet({ open, onOpenChange, month }: AddEntrySheetProps)
           <div className="px-4 pb-4">
             <SheetSubmitButton
               pendingChildren="追加中..."
-              className="w-full h-12 bg-accent text-accent-foreground rounded-[12px] text-[15px] font-bold text-center shadow-fab transition-opacity"
+              className="w-full h-12 bg-accent text-accent-foreground rounded-[12px] text-[15px] font-bold text-center shadow-fab transition-colors hover:bg-sky-700 dark:hover:bg-sky-300"
             >
               {TYPE_LABELS[entryType]}を追加
             </SheetSubmitButton>

--- a/src/features/add-entry/index.tsx
+++ b/src/features/add-entry/index.tsx
@@ -18,7 +18,7 @@ export function AddEntryFab({ month }: AddEntryFabProps) {
         type="button"
         onClick={() => setOpen(true)}
         aria-label="項目を追加"
-        className="fixed right-4 bottom-[calc(env(safe-area-inset-bottom)+1.25rem)] z-40 md:hidden rounded-full bg-accent text-accent-foreground px-5 py-3.5 shadow-fab flex items-center gap-1.5 active:scale-95 transition-transform"
+        className="fixed right-4 bottom-[calc(env(safe-area-inset-bottom)+1.25rem)] z-40 md:hidden rounded-full bg-gradient-to-r from-sky-700 to-orange-600 px-5 py-3.5 text-white shadow-fab flex items-center gap-1.5 active:scale-95 transition-transform dark:from-sky-300 dark:to-orange-300 dark:text-slate-950"
       >
         <span className="text-base font-semibold">+</span>
         <span className="text-[13px] font-semibold">項目を追加</span>

--- a/src/features/monthly-list/components/month-row.tsx
+++ b/src/features/monthly-list/components/month-row.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import { ChevronRight } from 'lucide-react'
 import { formatCurrency, formatMonth, monthToPath } from '@/lib/utils/format'
 import type { MonthlySummary } from '@/types'
 
@@ -81,8 +82,9 @@ export function MonthRow({
         >
           {formatCurrency(summary.balance, { signed: true })}
         </span>
-        <span className="text-[10px] font-medium text-accent">
-          View &gt;
+        <span className="inline-flex items-center gap-0.5 text-[10px] font-medium text-accent">
+          View
+          <ChevronRight className="h-3 w-3" aria-hidden="true" />
         </span>
       </div>
     </Link>

--- a/src/features/monthly-list/index.tsx
+++ b/src/features/monthly-list/index.tsx
@@ -100,7 +100,7 @@ export function MonthlyListSection({ summaries, year }: MonthlyListSectionProps)
 
       {/* Year-to-Date カード */}
       {recordedCount > 0 && (
-        <div className="rounded-[16px] shadow-soft p-5">
+        <div className="rounded-[16px] border border-sky-100/80 bg-card p-5 shadow-soft dark:border-white/10">
           <div className="text-[10px] font-medium tracking-[0.5px] text-muted-foreground uppercase">
             Year-to-Date / 年間収支
           </div>

--- a/src/features/monthly-overview/index.tsx
+++ b/src/features/monthly-overview/index.tsx
@@ -9,7 +9,6 @@ import { AnimatedYen } from '@/components/animations/animated-number'
 import { CopyMonthDialog } from '@/features/copy-month'
 import { ExportCsvButton } from '@/features/export-csv'
 import { HeaderActions } from '@/components/layout/header-actions'
-import { useTheme } from 'next-themes'
 import { labelSlide, motionDuration, motionEase } from '@/components/animations/tokens'
 import {
   calculateSettlement,
@@ -61,8 +60,6 @@ export function HeroSection({
   children,
 }: HeroSectionProps) {
   const router = useRouter()
-  const { resolvedTheme } = useTheme()
-  const isDark = resolvedTheme === 'dark'
   const direction = useMonthDirection(currentMonth)
   const previousMonth = getPreviousMonth(currentMonth)
 
@@ -83,40 +80,11 @@ export function HeroSection({
   }
 
   return (
-    <section
-      className="relative overflow-hidden"
-      style={{
-        background: isDark
-          ? `
-            linear-gradient(to bottom, transparent 65%, #0F1117AA 85%, #0F1117 100%),
-            radial-gradient(at 0% 0%, #1E2A6E 0%, transparent 50%),
-            radial-gradient(at 50% 0%, #2A1F6E 0%, transparent 50%),
-            radial-gradient(at 100% 0%, #1E3A8A 0%, transparent 50%),
-            radial-gradient(at 0% 50%, #312E81 0%, transparent 50%),
-            radial-gradient(at 50% 50%, #2E4A8E 0%, transparent 50%),
-            radial-gradient(at 100% 50%, #1E5A8A 0%, transparent 50%),
-            radial-gradient(at 0% 100%, #1E1B4B 0%, transparent 50%),
-            radial-gradient(at 50% 100%, #172554 0%, transparent 50%),
-            radial-gradient(at 100% 100%, #164E63 0%, transparent 50%)
-          `
-          : `
-            linear-gradient(to bottom, transparent 65%, #FAFBFCAA 85%, #FAFBFC 100%),
-            radial-gradient(at 0% 0%, #3454D1 0%, transparent 50%),
-            radial-gradient(at 50% 0%, #4C3BCF 0%, transparent 50%),
-            radial-gradient(at 100% 0%, #3B82F6 0%, transparent 50%),
-            radial-gradient(at 0% 50%, #6366F1 0%, transparent 50%),
-            radial-gradient(at 50% 50%, #5B8DEF 0%, transparent 50%),
-            radial-gradient(at 100% 50%, #38BDF8 0%, transparent 50%),
-            radial-gradient(at 0% 100%, #C7D2FE 0%, transparent 50%),
-            radial-gradient(at 50% 100%, #DBEAFE 0%, transparent 50%),
-            radial-gradient(at 100% 100%, #BAE6FD 0%, transparent 50%)
-          `,
-      }}
-    >
+    <section className="relative overflow-hidden border-b bg-gradient-to-b from-sky-50 via-background to-orange-50/70 dark:from-sky-950/25 dark:via-background dark:to-orange-950/15">
       <div className="relative flex flex-col gap-3 pt-[calc(env(safe-area-inset-top)+16px)] px-5 pb-7">
         {/* Header — 月一覧と同じ */}
         <div className="flex items-center justify-between">
-          <span className="text-[12px] font-bold tracking-[1px] text-white uppercase">
+          <span className="text-[12px] font-bold tracking-[1px] text-sky-900 uppercase dark:text-white">
             Score Splitter
           </span>
           <HeaderActions variant="hero" />
@@ -127,7 +95,7 @@ export function HeroSection({
           <Link
             href={`/${currentMonth.slice(0, 4)}`}
             aria-label="月の一覧へ戻る"
-            className="inline-flex items-center gap-1 text-white/70 text-xs hover:text-white transition-colors shrink-0"
+            className="inline-flex items-center gap-1 text-sky-900/70 text-xs hover:text-sky-950 transition-colors shrink-0 dark:text-white/70 dark:hover:text-white"
           >
             <span>←</span>
             <span>一覧へ</span>
@@ -138,7 +106,7 @@ export function HeroSection({
               type="button"
               aria-label="前月に移動"
               onClick={() => navigateMonth(-1)}
-              className="inline-flex h-11 w-11 items-center justify-center rounded-full text-white/80 hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+              className="inline-flex h-11 w-11 items-center justify-center rounded-full text-sky-900/75 transition-colors hover:bg-sky-100/80 hover:text-sky-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-600/40 dark:text-white/75 dark:hover:bg-white/10 dark:hover:text-white dark:focus-visible:ring-white/60"
             >
               <ChevronLeft className="h-4 w-4" />
             </button>
@@ -147,7 +115,7 @@ export function HeroSection({
               onClick={goToCurrentMonth}
               aria-label="今月に移動"
               aria-live="polite"
-              className="inline-flex h-11 min-w-[88px] items-center justify-center overflow-hidden rounded-full text-center text-[13px] font-semibold text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+              className="inline-flex h-11 min-w-[88px] items-center justify-center overflow-hidden rounded-full text-center text-[13px] font-semibold text-sky-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-600/40 dark:text-white dark:focus-visible:ring-white/60"
             >
               <AnimatePresence mode="wait" initial={false} custom={direction}>
                 <motion.span
@@ -168,7 +136,7 @@ export function HeroSection({
               type="button"
               aria-label="翌月に移動"
               onClick={() => navigateMonth(1)}
-              className="inline-flex h-11 w-11 items-center justify-center rounded-full text-white/80 hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+              className="inline-flex h-11 w-11 items-center justify-center rounded-full text-sky-900/75 transition-colors hover:bg-sky-100/80 hover:text-sky-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-600/40 dark:text-white/75 dark:hover:bg-white/10 dark:hover:text-white dark:focus-visible:ring-white/60"
             >
               <ChevronRight className="h-4 w-4" />
             </button>
@@ -190,24 +158,24 @@ export function HeroSection({
 
 
         {/* 区切り線 */}
-        <div className="h-px bg-white/10 w-full" />
+        <div className="h-px bg-sky-900/10 w-full dark:bg-white/10" />
 
         {/* Balance */}
         <div className="flex flex-col items-center gap-1.5 py-3">
-          <span className="text-[10px] font-semibold tracking-[0.8px] text-white/70 uppercase">
+          <span className="text-[10px] font-semibold tracking-[0.8px] text-sky-900/65 uppercase dark:text-white/70">
             Balance / 月の収支
           </span>
-          <span className="text-sm font-medium font-mono text-white/50">
+          <span className="text-sm font-medium font-mono text-sky-900/50 dark:text-white/50">
             {formatMonthDot(currentMonth)}
           </span>
           <AnimatedYen
             value={monthlyBalance}
-            className="text-4xl font-bold font-mono text-white tracking-tight"
+            className="text-4xl font-bold font-mono text-slate-950 tracking-tight dark:text-white"
           />
-          <span className="text-[11px] text-white/70">
+          <span className="text-[11px] text-sky-900/65 dark:text-white/70">
             収入 {formatCurrency(result.totalIncome)} − 支出 {formatCurrency(allExpenseTotal, { absolute: true })}
           </span>
-          <span className="inline-flex items-center px-2.5 py-1 rounded-full bg-white/10 text-[10px] text-white/80">
+          <span className="inline-flex items-center px-2.5 py-1 rounded-full bg-sky-100/80 text-[10px] text-sky-950 dark:bg-white/10 dark:text-white/80">
             {m}月1日 — {days}日間 / {totalItems}件の取引
           </span>
         </div>
@@ -215,7 +183,7 @@ export function HeroSection({
         {/* Mini Cards */}
         <div className="flex gap-2.5">
           {/* Allowance */}
-          <div className="flex-1 rounded-[12px] bg-card shadow-sm p-3">
+          <div className="flex-1 rounded-[12px] border border-sky-100/70 bg-background/90 p-3 shadow-sm dark:border-white/10 dark:bg-card/90">
             <span className="text-[9px] font-medium tracking-[0.5px] text-muted-foreground uppercase block">
               Allowance / お小遣い
             </span>
@@ -226,7 +194,7 @@ export function HeroSection({
           </div>
 
           {/* Settlement */}
-          <div className="flex-1 rounded-[12px] bg-card shadow-sm p-3">
+          <div className="flex-1 rounded-[12px] border border-sky-100/70 bg-background/90 p-3 shadow-sm dark:border-white/10 dark:bg-card/90">
             <span className="text-[9px] font-medium tracking-[0.5px] text-muted-foreground uppercase block">
               Settlement / 精算額
             </span>

--- a/src/features/passkey/components/passkey-login-button.tsx
+++ b/src/features/passkey/components/passkey-login-button.tsx
@@ -64,7 +64,7 @@ export function PasskeyLoginButton() {
         type="button"
         onClick={handlePasskeyLogin}
         disabled={isAuthenticating}
-        className="w-full h-12 px-5 bg-foreground text-background rounded-[12px] text-[13px] font-bold tracking-[0.10em] flex items-center justify-center gap-2 disabled:opacity-50 transition-opacity"
+        className="w-full h-12 px-5 rounded-[12px] border border-sky-100/80 bg-background text-foreground text-[13px] font-bold tracking-[0.10em] flex items-center justify-center gap-2 shadow-sm disabled:opacity-50 transition-colors hover:bg-sky-50 dark:border-white/10 dark:bg-muted dark:hover:bg-muted/80"
       >
         <Key className="h-4 w-4" />
         {isAuthenticating ? '認証中…' : 'パスキーでログイン'}

--- a/src/features/passkey/components/register-passkey-form.tsx
+++ b/src/features/passkey/components/register-passkey-form.tsx
@@ -125,7 +125,7 @@ export function RegisterPasskeyForm({ onRegistered }: RegisterPasskeyFormProps) 
           value={deviceName}
           onChange={(e) => setDeviceName(e.target.value)}
           placeholder="例: iPhone, 1Password"
-          className="w-full h-10 rounded-[10px] bg-muted px-3 text-[13px] border-none outline-none placeholder:text-muted-foreground/50"
+          className="w-full h-10 rounded-[10px] bg-sky-50/80 px-3 text-[13px] border-none outline-none placeholder:text-muted-foreground/50 focus-visible:ring-2 focus-visible:ring-ring/50 dark:bg-muted"
         />
       </div>
 
@@ -139,7 +139,7 @@ export function RegisterPasskeyForm({ onRegistered }: RegisterPasskeyFormProps) 
       <Button
         onClick={handleRegister}
         disabled={isRegistering}
-        className="w-full h-11 rounded-[12px] bg-accent text-accent-foreground text-[13px] font-bold tracking-[0.10em]"
+        className="w-full h-11 rounded-[12px] bg-accent text-accent-foreground text-[13px] font-bold tracking-[0.10em] shadow-fab hover:bg-sky-700 dark:hover:bg-sky-300"
       >
         <Plus className="h-4 w-4 mr-1.5" />
         {isRegistering ? '登録中…' : 'パスキーを登録'}

--- a/tests/e2e/household-flow.spec.ts
+++ b/tests/e2e/household-flow.spec.ts
@@ -10,7 +10,7 @@ test.beforeEach(async ({ request }) => {
 async function login(page: Page) {
   await page.goto('/login')
   await page.getByPlaceholder('パスワード').fill(MOCK_PASSWORD)
-  await page.getByRole('button', { name: 'ログイン →' }).click()
+  await page.getByRole('button', { name: 'ログイン', exact: true }).click()
   await page.waitForURL(/\/\d{4}\/\d{2}/)
 }
 
@@ -37,12 +37,14 @@ test.describe('ログインページ', () => {
   test('ログインフォームが表示される', async ({ page }) => {
     await expect(page.getByRole('heading', { name: 'Score Splitter' })).toBeVisible()
     await expect(page.getByPlaceholder('パスワード')).toBeVisible()
-    await expect(page.getByRole('button', { name: 'ログイン →' })).toBeVisible()
+    await expect(
+      page.getByRole('button', { name: 'ログイン', exact: true })
+    ).toBeVisible()
   })
 
   test('不正なパスワードでエラーが表示される', async ({ page }) => {
     await page.getByPlaceholder('パスワード').fill('wrong-password')
-    await page.getByRole('button', { name: 'ログイン →' }).click()
+    await page.getByRole('button', { name: 'ログイン', exact: true }).click()
 
     await expect(
       page.getByText(/パスワードが正しくありません/)
@@ -51,7 +53,7 @@ test.describe('ログインページ', () => {
 
   test('正しいパスワードで月詳細に遷移する', async ({ page }) => {
     await page.getByPlaceholder('パスワード').fill(MOCK_PASSWORD)
-    await page.getByRole('button', { name: 'ログイン →' }).click()
+    await page.getByRole('button', { name: 'ログイン', exact: true }).click()
     await page.waitForURL(/\/\d{4}\/\d{2}/)
 
     await expect(page.getByText(/Balance/)).toBeVisible()

--- a/tests/e2e/reduced-motion.spec.ts
+++ b/tests/e2e/reduced-motion.spec.ts
@@ -10,7 +10,7 @@ test.beforeEach(async ({ request }) => {
 async function login(page: Page) {
   await page.goto('/login')
   await page.getByPlaceholder('パスワード').fill(MOCK_PASSWORD)
-  await page.getByRole('button', { name: 'ログイン →' }).click()
+  await page.getByRole('button', { name: 'ログイン', exact: true }).click()
   await page.waitForURL(/\/\d{4}\/\d{2}/)
 }
 

--- a/tests/unit/styles/globals.test.ts
+++ b/tests/unit/styles/globals.test.ts
@@ -6,7 +6,7 @@ describe('globals.css', () => {
   it('ライトモードのmuted-foregroundは白背景で読める濃さにする', () => {
     const css = readFileSync(join(process.cwd(), 'src/app/globals.css'), 'utf-8')
 
-    expect(css).toContain('--muted-foreground: #767676;')
+    expect(css).toContain('--muted-foreground: #64748B;')
     expect(css).not.toContain('--muted-foreground: #999999;')
   })
 


### PR DESCRIPTION
## 概要
- /lp の淡いsky背景とorangeアクセントをアプリ全体のテーマトークンへ反映
- 月次ヒーロー、ログイン、設定、月一覧、追加フォーム、パスキーUIの見た目を統一
- 新しいUIに合わせてE2Eとスタイルテストを更新

## 確認
- npm run lint
- npm run test:run
- npm run test:e2e
- git diff --check
- Playwrightで主要画面を目視確認