### PR TITLE
fix: ログイン画面の横スクロールを防止する

### DIFF
--- a/src/app/login/login-form.tsx
+++ b/src/app/login/login-form.tsx
@@ -58,7 +58,7 @@ export function LoginForm() {
                   placeholder="パスワード"
                   required
                   autoFocus
-                  className="flex-1 text-[20px] font-semibold tracking-[0.30em] bg-transparent border-none outline-none font-tabular placeholder:text-muted-foreground/40 placeholder:tracking-normal placeholder:text-base"
+                  className="min-w-0 flex-1 text-[20px] font-semibold tracking-[0.30em] bg-transparent border-none outline-none font-tabular placeholder:text-muted-foreground/40 placeholder:tracking-normal placeholder:text-base"
                 />
                 <button
                   type="button"

--- a/tests/components/login-page.test.tsx
+++ b/tests/components/login-page.test.tsx
@@ -54,6 +54,14 @@ describe('LoginPage', () => {
     expect(screen.getByRole('button', { name: 'テーマを切り替え' })).toHaveClass('size-11')
   })
 
+  it('パスワード入力欄をカード幅まで縮小できる', async () => {
+    vi.mocked(isAuthenticated).mockResolvedValue(false)
+
+    render(await LoginPage())
+
+    expect(screen.getByPlaceholderText('パスワード')).toHaveClass('min-w-0')
+  })
+
   it('認証済みの場合はトップページへリダイレクトする', async () => {
     vi.mocked(isAuthenticated).mockResolvedValue(true)
 

--- a/tests/e2e/household-flow.spec.ts
+++ b/tests/e2e/household-flow.spec.ts
@@ -34,6 +34,27 @@ test.describe('ログインページ', () => {
     await page.goto('/login')
   })
 
+  test('スマホ幅で横スクロールせずにフォーム全体を表示する', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 })
+    await page.reload()
+
+    const viewportWidth = await page.evaluate(() =>
+      document.documentElement.clientWidth
+    )
+    const contentWidth = await page.evaluate(() =>
+      document.documentElement.scrollWidth
+    )
+
+    expect(contentWidth).toBe(viewportWidth)
+    await expect(page.getByPlaceholder('パスワード')).toBeInViewport()
+    await expect(
+      page.getByRole('button', { name: 'ログイン', exact: true })
+    ).toBeInViewport()
+    await expect(
+      page.getByRole('button', { name: 'パスキーでログイン' })
+    ).toBeInViewport()
+  })
+
   test('ログインフォームが表示される', async ({ page }) => {
     await expect(page.getByRole('heading', { name: 'ヤマワケ' })).toBeVisible()
     await expect(page.getByPlaceholder('パスワード')).toBeVisible()


### PR DESCRIPTION
## Summary
- パスワード入力欄に `min-w-0` を追加し、カード幅まで自然に縮小できるようにした
- ログイン画面のコンポーネントテストで、入力欄に必要なクラスが付与されることを確認した
- Playwright の E2E テストで、スマホ幅でも横スクロールせず主要要素が画面内に収まることを検証した

## Testing
- コンポーネントテストを追加して、パスワード入力欄のレイアウト制約を確認
- E2E テストを追加して、狭いビューポートでフォーム全体が表示されることを確認
- 実行は未実施